### PR TITLE
add MaxFlow and test for it

### DIFF
--- a/src/max_flow.rb
+++ b/src/max_flow.rb
@@ -1,0 +1,129 @@
+# frozen_string_literal: true
+
+# MaxFlowGraph
+class MaxFlow
+  def initialize(n = 0)
+    @n   = n
+    @pos = []
+    @g   = Array.new(n) { [] }
+  end
+
+  def add_edge(from, to, cap)
+    edge_number = @pos.size
+
+    @pos << [from, @g[from].size]
+
+    from_id = @g[from].size
+    to_id   = @g[to].size
+    to_id += 1 if from == to
+    @g[from] << [to,   to_id,   cap]
+    @g[to]   << [from, from_id, 0]
+
+    edge_number
+  end
+
+  def push(edge)
+    add_edge(*edge)
+  end
+  alias << push
+
+  # return edge = [from, to, cap, flow]
+  def [](i)
+    _e  = @g[@pos[i][0]][@pos[i][1]]
+    _re = @g[_e[0]][_e[1]]
+    [@pos[i][0], _e[0], _e[-1] + _re[-1], _re[-1]]
+  end
+  alias get_edge []
+  alias edge []
+
+  def edges
+    @pos.map do |(to, rev, _cap)|
+      _e  = @g[to][rev]
+      _re = @g[_e[0]][_e[1]]
+      [to, _e[0], _e[-1] + _re[-1], _re[-1]]
+    end
+  end
+
+  def flow(s, t, flow_limit = 1 << 64)
+    level = Array.new(@n)
+    iter  = Array.new(@n)
+    que   = []
+
+    flow = 0
+    while flow < flow_limit
+      bfs(level, que, s, t)
+      break if level[t] == -1
+
+      iter.fill(0)
+      while flow < flow_limit
+        f = dfs(t, flow_limit - flow, s, level, iter)
+        break if f == 0
+
+        flow += f
+      end
+    end
+
+    flow
+  end
+  alias max_flow flow
+
+  def min_cut(s)
+    visited = Array.new(@n) { false }
+    que = [s]
+    while (q = que.shift)
+      visited[q] = true
+      @g[q].each do |(to, _rev, cap)|
+        if cap > 0 && !visited[to]
+          visited[to] = true
+          que << to
+        end
+      end
+    end
+    visited
+  end
+
+  private
+
+  def bfs(level, que, s, t)
+    level.fill(-1)
+    level[s] = 0
+    que.clear
+    que << s
+
+    while (v = que.shift)
+      @g[v].each do |e|
+        next if e[2] == 0 || level[e[0]] >= 0
+
+        level[e[0]] = level[v] + 1
+        return nil if e[0] == t
+
+        que << e[0]
+      end
+    end
+  end
+
+  def dfs(v, up, s, level, iter)
+    return up if v == s
+
+    res = 0
+    level_v = level[v]
+
+    iter[v].upto(@g[v].size - 1) do |i|
+      e = @g[v][i]
+      next if level_v <= level[e[0]] || @g[e[0]][e[1]][2] == 0
+
+      d = dfs(e[0], [up - res, @g[e[0]][e[1]][2]].min, s, level, iter)
+      next if d <= 0
+
+      @g[v][i][2] += d
+      @g[e[0]][e[1]][2] -= d
+      res += d
+      break if res == up
+    end
+
+    res
+  end
+end
+
+MaxFlowGraph = MaxFlow
+MFGraph      = MaxFlow

--- a/src/max_flow.rb
+++ b/src/max_flow.rb
@@ -44,6 +44,13 @@ class MaxFlow
     end
   end
 
+  def change_edge(i, new_cap, new_flow)
+    _e  = @g[@pos[i][0]][@pos[i][1]]
+    _re = @g[_e[0]][_e[1]]
+    _e[2]  = new_cap - new_flow
+    _re[2] = new_flow
+  end
+
   def flow(s, t, flow_limit = 1 << 64)
     level = Array.new(@n)
     iter  = Array.new(@n)

--- a/src/max_flow.rb
+++ b/src/max_flow.rb
@@ -37,7 +37,7 @@ class MaxFlow
   alias edge []
 
   def edges
-    @pos.map do |(to, rev, _cap)|
+    @pos.map do |(to, rev)|
       _e  = @g[to][rev]
       _re = @g[_e[0]][_e[1]]
       [to, _e[0], _e[-1] + _re[-1], _re[-1]]

--- a/src/max_flow.rb
+++ b/src/max_flow.rb
@@ -37,10 +37,10 @@ class MaxFlow
   alias edge []
 
   def edges
-    @pos.map do |(to, rev)|
-      _e  = @g[to][rev]
+    @pos.map do |(from, id)|
+      _e  = @g[from][id]
       _re = @g[_e[0]][_e[1]]
-      [to, _e[0], _e[-1] + _re[-1], _re[-1]]
+      [from, _e[0], _e[-1] + _re[-1], _re[-1]]
     end
   end
 
@@ -115,17 +115,20 @@ class MaxFlow
     res = 0
     level_v = level[v]
 
-    iter[v].upto(@g[v].size - 1) do |i|
+    while iter[v] < @g[v].size
+      i = iter[v]
       e = @g[v][i]
-      next if level_v <= level[e[0]] || @g[e[0]][e[1]][2] == 0
-
-      d = dfs(e[0], [up - res, @g[e[0]][e[1]][2]].min, s, level, iter)
-      next if d <= 0
-
-      @g[v][i][2] += d
-      @g[e[0]][e[1]][2] -= d
-      res += d
-      break if res == up
+      cap = @g[e[0]][e[1]][2]
+      if level_v > level[e[0]] && cap > 0
+        d = dfs(e[0], (up - res < cap ? up - res : cap), s, level, iter)
+        if d > 0
+          @g[v][i][2] += d
+          @g[e[0]][e[1]][2] -= d
+          res += d
+          break if res == up
+        end
+      end
+      iter[v] += 1
     end
 
     res

--- a/test/max_flow_test.rb
+++ b/test/max_flow_test.rb
@@ -1,0 +1,84 @@
+# frozen_string_literal: true
+
+require 'minitest'
+require 'minitest/autorun'
+
+require_relative '../src/max_flow.rb'
+
+class MaxFlowTest < Minitest::Test
+  def test_simple
+    g = MaxFlowGraph.new(4)
+    assert_equal 0, g.add_edge(0, 1, 1)
+    assert_equal 1, g.add_edge(0, 2, 1)
+    assert_equal 2, g.add_edge(1, 3, 1)
+    assert_equal 3, g.add_edge(2, 3, 1)
+    assert_equal 4, g.add_edge(1, 2, 1)
+
+    assert_equal 2, g.flow(0, 3)
+
+    edges = [
+      [0, 1, 1, 1],
+      [0, 2, 1, 1],
+      [1, 3, 1, 1],
+      [2, 3, 1, 1],
+      [1, 2, 1, 0],
+    ]
+    edges.each_with_index do |edge, i|
+      assert_equal edge, g.get_edge(i)
+      assert_equal edge, g.edge(i)
+      assert_equal edge, g[i]
+    end
+    assert_equal edges, g.edges
+    assert_equal [true, false, false, false], g.min_cut(0)
+  end
+
+  def test_not_simple
+    g = MaxFlowGraph.new(2)
+    assert_equal 0, g.add_edge(0, 1, 1)
+    assert_equal 1, g.add_edge(0, 1, 2)
+    assert_equal 2, g.add_edge(0, 1, 3)
+    assert_equal 3, g.add_edge(0, 1, 4)
+    assert_equal 4, g.add_edge(0, 1, 5)
+    assert_equal 5, g.add_edge(0, 0, 6)
+    assert_equal 6, g.add_edge(1, 1, 7)
+
+    assert_equal 15, g.flow(0, 1)
+
+    assert_equal [0, 1, 1, 1], g.get_edge(0)
+    assert_equal [0, 1, 2, 2], g.get_edge(1)
+    assert_equal [0, 1, 3, 3], g.get_edge(2)
+    assert_equal [0, 1, 4, 4], g.get_edge(3)
+    assert_equal [0, 1, 5, 5], g.get_edge(4)
+    assert_equal [true, false], g.min_cut(0)
+  end
+
+  def test_cut
+    g = MaxFlowGraph.new(3)
+    assert_equal 0, g.add_edge(0, 1, 2)
+    assert_equal 1, g.add_edge(1, 2, 1)
+
+    assert_equal 1, g.flow(0, 2)
+
+    assert_equal [0, 1, 2, 1], g[0]
+    assert_equal [1, 2, 1, 1], g[1]
+    assert_equal [true, true, false], g.min_cut(0)
+  end
+
+  # https://github.com/atcoder/ac-library/issues/1
+  # https://twitter.com/Mi_Sawa/status/1303170874938331137
+  def test_self_loop
+    g = MaxFlowGraph.new(3)
+    assert_equal 0, g.add_edge(0, 0, 100)
+    assert_equal [0, 0, 100, 0], g.edge(0)
+  end
+
+  def test_aizu_grl6
+    g = MaxFlow.new(4)
+    assert_equal 0, g.add_edge(0, 1, 2)
+    assert_equal 1, g.add_edge(0, 2, 1)
+    assert_equal 2, g.add_edge(1, 2, 1)
+    assert_equal 3, g.add_edge(1, 3, 1)
+    assert_equal 4, g.add_edge(2, 3, 2)
+    assert_equal 3, g.max_flow(0, 4 - 1)
+  end
+end

--- a/test/max_flow_test.rb
+++ b/test/max_flow_test.rb
@@ -93,6 +93,34 @@ class MaxFlowTest < Minitest::Test
     assert_equal [1, 2, 1, 0], g.edge(2)
   end
 
+  def test_typical_mistake
+    n = 100
+    g = MaxFlow.new(n)
+    s, a, b, c, t = *0..4
+    uv = [5, 6]
+
+    g.add_edge(s, a, 1)
+    g.add_edge(s, b, 2)
+    g.add_edge(b, a, 2)
+    g.add_edge(c, t, 2)
+    uv.each { |x| g.add_edge(a, x, 3) }
+
+    loop do
+      next_uv = uv.map { |x| x + 2 }
+      break if next_uv[1] >= n
+
+      uv.each  do |x|
+        next_uv.each do |y|
+          g.add_edge(x, y, 3)
+        end
+      end
+      uv = next_uv
+    end
+    uv.each { |x| g.add_edge(x, c, 3) }
+
+    assert_equal 2, g.max_flow(s, t)
+  end
+
   # https://github.com/atcoder/ac-library/issues/1
   # https://twitter.com/Mi_Sawa/status/1303170874938331137
   def test_self_loop

--- a/test/max_flow_test.rb
+++ b/test/max_flow_test.rb
@@ -64,6 +64,35 @@ class MaxFlowTest < Minitest::Test
     assert_equal [true, true, false], g.min_cut(0)
   end
 
+  def test_twice
+    g = MaxFlowGraph.new(3)
+    assert_equal 0, g.add_edge(0, 1, 1)
+    assert_equal 1, g.add_edge(0, 2, 1)
+    assert_equal 2, g.add_edge(1, 2, 1)
+
+    assert_equal 2, g.max_flow(0, 2)
+
+    assert_equal [0, 1, 1, 1], g.edge(0)
+    assert_equal [0, 2, 1, 1], g.edge(1)
+    assert_equal [1, 2, 1, 1], g.edge(2)
+
+    g.change_edge(0, 100, 10)
+    assert_equal [0, 1, 100, 10], g.edge(0)
+
+    assert_equal 0, g.max_flow(0, 2)
+    assert_equal 90, g.max_flow(0, 1)
+
+    assert_equal [0, 1, 100, 100], g.edge(0)
+    assert_equal [0, 2, 1, 1], g.edge(1)
+    assert_equal [1, 2, 1, 1], g.edge(2)
+
+    assert_equal 2, g.max_flow(2, 0)
+
+    assert_equal [0, 1, 100, 99], g.edge(0)
+    assert_equal [0, 2, 1, 0], g.edge(1)
+    assert_equal [1, 2, 1, 0], g.edge(2)
+  end
+
   # https://github.com/atcoder/ac-library/issues/1
   # https://twitter.com/Mi_Sawa/status/1303170874938331137
   def test_self_loop


### PR DESCRIPTION
Issue #9 に対応したものです。 

kuma-rbさんの許可を頂いているので、kuma-rbさんのコードと本家ACLコードをベースに追加しています。
メソッド内に定義されたbfsメソッド・dfsメソッドは、private関数に切り出しています。こちらの方が少し速いようです。
(メソッド内にメソッド定義をすると、推測ですが、何度も定義することで遅くなっているかもしれないです)
クラス名とファイル名は対応させた方が良いと思い、クラス名をファイル名に合わせました。その上でクラス名のエイリアスをつけました。
あと、本家ACLでは、flowメソッドですが、max_flowと名付けるのも一般的なようなので、max_flowメソッドをエイリアスにもたせています。

本家ACLコードに合わせて`_e`や`_re`の変数名を用いましたが、RuboCopだと`W`レベルの警告が出ますけど、問題ないのではと思ったので残しました。

辺が配列ですが、Structなどを用いてEdgeクラスを作るのもアリかもしれません。遅くなるかなと思い、そのままです。
