### PR TITLE
improve time by changing array init and bit operation

### DIFF
--- a/src/fenwick_tree.rb
+++ b/src/fenwick_tree.rb
@@ -6,11 +6,11 @@ class FenwickTree
     case arg
     when Array
       @size = arg.size
-      @data = Array.new(@size + 1) { 0 }
+      @data = Array.new(@size + 1, 0)
       arg.each.with_index(1) { |e, i| add(i, e) }
     when Integer
       @size = arg
-      @data = Array.new(@size + 1) { 0 }
+      @data = Array.new(@size + 1, 0)
     else
       raise ArgumentError
     end
@@ -31,7 +31,7 @@ class FenwickTree
     res = 0
     while i > 0
       res += @data[i]
-      i -= (i & -i)
+      i &= i - 1
     end
     res
   end


### PR DESCRIPTION
```ruby
# Bad
Array.new(n) { 0 }
i -= ( i & -i )

# Good
Array.new(n, 0)
i &= i - 1
```

Ruby 2.7.1
```ruby
require "benchmark"

n = 10 ** 6

Benchmark.bm 10 do |r|
  r1 = r.report "new(n, 0)" do
    a = Array.new(n, 0)
  end

  r2 = r.report "new(n){ 0 }" do
    b = Array.new(n) { 0 }
  end

  r3 = r.report "[0] * n" do
    c = [0] * n
  end
end

#                  user     system      total        real
# new(n, 0)    0.001462   0.001919   0.003381 (  0.003376)
# new(n){ 0 }  0.037199   0.001973   0.039172 (  0.039203)
# [0] * n      0.003595   0.003189   0.006784 (  0.007078)
```

```ruby
require "benchmark"

n = 10 ** 6
a = Array.new(n) { rand(1 .. n) }

Benchmark.bm 6 do |r|
  r1 = r.report "before" do
    a.each do |i|
      while i > 0
        i -= ( i & -i )
      end
    end
  end
  
  r2 = r.report "after" do
    a.each do |i|
      while i > 0
        i &= i - 1
      end
    end
  end
end

#              user     system      total        real
# before   0.305110   0.000196   0.305306 (  0.305608)
# after    0.192453   0.000140   0.192593 (  0.192682)
```