### PR TITLE
Add modint

### DIFF
--- a/src/modint.rb
+++ b/src/modint.rb
@@ -22,10 +22,6 @@ class ModInt < Numeric
     return x
   end
 
-  def self.[](val = 0, mod = nil)
-    return new(val, mod)
-  end
-
   def initialize(val = 0, mod = nil)
     val = 1 if true == val
     val = 0 if false == val
@@ -199,4 +195,8 @@ class ModInt < Numeric
       return [s, m0]
     end
   end
+end
+
+def ModInt(val = 0, mod = nil)
+  return ModInt.new(val, mod)
 end

--- a/src/modint.rb
+++ b/src/modint.rb
@@ -1,0 +1,184 @@
+class ModInt < Numeric
+
+  def self.set_mod(mod)
+    raise ArgumentError unless mod.is_a? Integer and 1 <= mod
+    @@mod, @@bt = mod, Barrett.new(mod)
+  end
+
+  attr_reader :val, :mod
+  alias to_i val
+
+  def self.raw(val, mod = @@mod, is_prime = false)
+    x = allocate
+    x.val, x.mod, x.is_prime = val, mod, is_prime
+  end
+
+  def initialize(val = 0, mod = @@mod)
+    val = 1 if true == val
+    val = 0 if false == val
+    raise ArgumentError unless val.is_a? Integer
+    @val, @mod, @is_prime = val % mod, mod, ModInt.is_prime(mod)
+  end
+
+  def succ!
+    @val += 1
+    @val = 0 if @val == @mod
+    return self
+  end
+
+  def pred!
+    @val = @mod if @val == 0
+    @val -= 1
+    return self
+  end
+
+  def add!(rhs)
+    @val += rhs.to_i
+    @val -= @mod if @val >= @mod
+    return self
+  end
+
+  def sub!(rhs)
+    @val -= rhs.to_i
+    @val -= @mod if @val >= @mod
+    return self
+  end
+
+  def mul!(rhs)
+    @val = @val * rhs.to_i % @mod
+    return self
+  end
+
+  def div!(rhs)
+    @val = @val * rhs.inv
+    return self
+  end
+
+  def +@
+    return self
+  end
+
+  def -@
+    return of_val(0).sub! self
+  end
+
+  def **(n)
+    raise ArgumentError unless n.is_a? Integer and 0 <= n
+    x, r = self, of_val(1)
+    while 0 < n
+      r.mul! x if (n & 1) == 1
+      x.mul! x
+      n >>= 1
+    end
+    return r
+  end
+
+  def inv
+    if @is_prime
+      raise RangeError if 0 == @val
+      return self ** (@mod - 2)
+    else
+      g, x = ModInt.inv_gcd(@val, @mod)
+      raise RangeError if 1 == g
+      return of_val(x)
+    end
+  end
+
+  def coerce(other)
+    [self, of_val(other % @mod)]
+  end
+
+  def +(rhs)
+    return dup.add! rhs
+  end
+
+  def -(rhs)
+    return dup.sub! rhs
+  end
+
+  def *(rhs)
+    return dup.mul! rhs
+  end
+
+  def /(rhs)
+    return dup.div! rhs
+  end
+
+  def ==(rhs)
+    return @val == rhs.val
+  end
+
+  def !=(rhs)
+    return @val != rhs.val
+  end
+
+  def dup
+    return Object.instance_method(:dup).bind(self).call
+  end
+
+  private
+
+  attr_writer :val, :mod, :is_prime
+
+  def of_val(val)
+    x = dup
+    x.val = val
+    return x
+  end
+
+  class Barrett
+    FULL32 = 0xffffffff
+    FULL64 = 0xffffffffffffffff
+
+    def initialize(m)
+      @umod, @im = m, FULL64 / m + 1
+    end
+
+    attr_reader :umod
+
+    def mul(a, b)
+      z = a & FULL64
+      z *= b
+      x = z * @im >> 64
+      v = z - x * @umod & FULL32
+      v += @umod if @umod <= v
+      return v
+    end
+  end
+
+  class << self
+    def is_prime(n)
+      return false if n <= 1
+      return true if n == 2 or n == 7 or n == 61
+      return false if (n & 1) == 0
+      d = n - 1
+      d >>= 1 while (d & 1) == 0
+      [2, 7, 61].each do |a|
+        t = d
+        y = a.pow(t, n)
+        while t != n - 1 and y != 1 and y != n - 1
+          y = y * y % n
+          t <<= 1
+        end
+        return false if y != n - 1 and (t & 1) == 0
+      end
+      return true
+    end
+
+    def inv_gcd(a, b)
+      a %= b # ruby's mod is safe
+      return [b, 0] if 0 == a
+      s, t = b, a
+      m0, m1 = 0, 1
+      while 0 != t
+        u = s / t
+        s -= t * u
+        m0 -= m1 * u
+        s, t = t, s
+        m0, m1 = m1, m0
+      end
+      m0 += b / s if m0 < 0
+      return [s, m0]
+    end
+  end
+end

--- a/src/modint.rb
+++ b/src/modint.rb
@@ -17,7 +17,7 @@ class ModInt < Numeric
       raise ArgumentError unless val.kind_of? Integer
       x = allocate
       x.val, x.mod, x.is_prime = val, mod, is_prime
-      return x
+      x
     end
 
     def prime?(n)
@@ -35,7 +35,7 @@ class ModInt < Numeric
         end
         return false if y != n - 1 and (t & 1) == 0
       end
-      return true
+      true
     end
 
     def inv_gcd(a, b)
@@ -51,7 +51,7 @@ class ModInt < Numeric
         m0, m1 = m1, m0
       end
       m0 += b / s if m0 < 0
-      return [s, m0]
+      [s, m0]
     end
   end
 
@@ -74,45 +74,45 @@ class ModInt < Numeric
   def inc!
     @val += 1
     @val = 0 if @val == @mod
-    return self
+    self
   end
 
   def dec!
     @val = @mod if @val == 0
     @val -= 1
-    return self
+    self
   end
 
   def add!(other)
     other = of_val(other) unless other.kind_of? ModInt
     @val = (@val + other.to_i) % @mod
-    return self
+    self
   end
 
   def sub!(other)
     other = of_val(other) unless other.kind_of? ModInt
     @val = (@val - other.to_i) % @mod
-    return self
+    self
   end
 
   def mul!(other)
     other = of_val(other) unless other.kind_of? ModInt
     @val = @val * other.to_i % @mod
-    return self
+    self
   end
 
   def div!(other)
     other = of_val(other) unless other.kind_of? ModInt
     mul! other.inv
-    return self
+    self
   end
 
   def +@
-    return self
+    self
   end
 
   def -@
-    return of_val(-self.to_i)
+    of_val(-self.to_i)
   end
 
   def **(n)
@@ -124,17 +124,17 @@ class ModInt < Numeric
       x.mul! x
       n >>= 1
     end
-    return r
+    r
   end
 
   def inv
     if @is_prime
       raise RangeError if 0 == @val
-      return self ** (@mod - 2)
+      self ** (@mod - 2)
     else
       g, x = ModInt.inv_gcd(@val, @mod)
       raise RangeError unless 1 == g
-      return of_val(x)
+      of_val(x)
     end
   end
 
@@ -143,31 +143,31 @@ class ModInt < Numeric
   end
 
   def +(other)
-    return dup.add! other
+    dup.add! other
   end
 
   def -(other)
-    return dup.sub! other
+    dup.sub! other
   end
 
   def *(other)
-    return dup.mul! other
+    dup.mul! other
   end
 
   def /(other)
-    return dup.div! other
+    dup.div! other
   end
 
   def ==(rhs)
-    return @val == rhs.val
+    @val == rhs.val
   end
 
   def !=(rhs)
-    return @val != rhs.val
+    @val != rhs.val
   end
 
   def dup
-    return Object.instance_method(:dup).bind(self).call
+    Object.instance_method(:dup).bind(self).call
   end
 
   def to_s
@@ -184,18 +184,19 @@ class ModInt < Numeric
     raise ArgumentError unless val.kind_of? Integer
     x = dup
     x.val = val % @mod
-    return x
+    x
   end
 end
 
 def ModInt(val = 0, mod = nil)
-  return ModInt.new(val, mod)
+  ModInt.new(val, mod)
 end
 
 class Integer
   def to_modint(mod = nil)
     ModInt.new(self, mod)
   end
+
   alias to_m to_modint
 end
 
@@ -203,5 +204,6 @@ class String
   def to_modint(mod = nil)
     ModInt.new(to_i, mod)
   end
+  
   alias to_m to_modint
 end

--- a/src/modint.rb
+++ b/src/modint.rb
@@ -50,28 +50,28 @@ class ModInt < Numeric
     return self
   end
 
-  def add!(rhs)
-    rhs = of_val(rhs) unless rhs.kind_of? ModInt
-    @val += rhs.to_i
+  def add!(other)
+    other = of_val(other) unless other.kind_of? ModInt
+    @val += other.to_i
     @val -= @mod if @val >= @mod
     return self
   end
 
-  def sub!(rhs)
-    rhs = of_val(rhs) unless rhs.kind_of? ModInt
-    @val = (@val - rhs.to_i) % @mod
+  def sub!(other)
+    other = of_val(other) unless other.kind_of? ModInt
+    @val = (@val - other.to_i) % @mod
     return self
   end
 
-  def mul!(rhs)
-    rhs = of_val(rhs) unless rhs.kind_of? ModInt
-    @val = @bt.mul(@val, rhs.to_i)
+  def mul!(other)
+    other = of_val(other) unless other.kind_of? ModInt
+    @val = @bt.mul(@val, other.to_i)
     return self
   end
 
-  def div!(rhs)
-    rhs = of_val(rhs) unless rhs.kind_of? ModInt
-    mul! rhs.inv
+  def div!(other)
+    other = of_val(other) unless other.kind_of? ModInt
+    mul! other.inv
     return self
   end
 
@@ -110,20 +110,20 @@ class ModInt < Numeric
     [of_val(other % @mod), self]
   end
 
-  def +(rhs)
-    return dup.add! rhs
+  def +(other)
+    return dup.add! other
   end
 
-  def -(rhs)
-    return dup.sub! rhs
+  def -(other)
+    return dup.sub! other
   end
 
-  def *(rhs)
-    return dup.mul! rhs
+  def *(other)
+    return dup.mul! other
   end
 
-  def /(rhs)
-    return dup.div! rhs
+  def /(other)
+    return dup.div! other
   end
 
   def ==(rhs)

--- a/src/modint.rb
+++ b/src/modint.rb
@@ -200,3 +200,17 @@ end
 def ModInt(val = 0, mod = nil)
   return ModInt.new(val, mod)
 end
+
+class Integer
+  def to_modint(mod = nil)
+    ModInt.new(self, mod)
+  end
+  alias to_m to_modint
+end
+
+class String
+  def to_modint(mod = nil)
+    ModInt.new(to_i, mod)
+  end
+  alias to_m to_modint
+end

--- a/src/modint.rb
+++ b/src/modint.rb
@@ -99,8 +99,7 @@ class ModInt < Numeric
   end
 
   def div!(other)
-    other = of_val(other) unless other.kind_of? ModInt
-    mul! other.inv
+    mul! inv_internal(other.to_i)
   end
 
   def +@
@@ -118,14 +117,7 @@ class ModInt < Numeric
   end
 
   def inv
-    if @is_prime
-      raise RangeError if 0 == @val
-      of_val(@val.pow(@mod - 2, @mod))
-    else
-      g, x = ModInt.inv_gcd(@val, @mod)
-      raise RangeError unless 1 == g
-      of_val(x)
-    end
+    of_val(inv_internal(@val))
   end
 
   def coerce(other)
@@ -173,6 +165,17 @@ class ModInt < Numeric
   def of_val(val)
     raise ArgumentError unless val.kind_of? Integer
     ModInt.raw(val % @mod, @mod, @is_prime)
+  end
+
+  def inv_internal(a)
+    if @is_prime
+      raise RangeError if 0 == a
+      a.pow(@mod - 2, @mod)
+    else
+      g, x = ModInt.inv_gcd(a, @mod)
+      raise RangeError unless 1 == g
+      x
+    end
   end
 end
 

--- a/src/modint.rb
+++ b/src/modint.rb
@@ -101,7 +101,6 @@ class ModInt < Numeric
   def div!(other)
     other = of_val(other) unless other.kind_of? ModInt
     mul! other.inv
-    self
   end
 
   def +@
@@ -109,7 +108,7 @@ class ModInt < Numeric
   end
 
   def -@
-    of_val(-self.to_i)
+    ModInt.raw(@mod - @val, @mod, @is_prime)
   end
 
   def **(n)
@@ -130,7 +129,7 @@ class ModInt < Numeric
   end
 
   def coerce(other)
-    [of_val(other % @mod), self]
+    [of_val(other), self]
   end
 
   def +(other)

--- a/src/modint.rb
+++ b/src/modint.rb
@@ -170,6 +170,10 @@ class ModInt < Numeric
     return Object.instance_method(:dup).bind(self).call
   end
 
+  def to_s
+    "#{val}"
+  end
+
   def inspect
     "#{val} mod #{mod}"
   end

--- a/src/modint.rb
+++ b/src/modint.rb
@@ -84,19 +84,16 @@ class ModInt < Numeric
   end
 
   def add!(other)
-    other = of_val(other) unless other.kind_of? ModInt
     @val = (@val + other.to_i) % @mod
     self
   end
 
   def sub!(other)
-    other = of_val(other) unless other.kind_of? ModInt
     @val = (@val - other.to_i) % @mod
     self
   end
 
   def mul!(other)
-    other = of_val(other) unless other.kind_of? ModInt
     @val = @val * other.to_i % @mod
     self
   end
@@ -165,7 +162,7 @@ class ModInt < Numeric
   end
 
   def to_s
-    "#{val}"
+    val.to_s
   end
 
   def inspect
@@ -176,9 +173,7 @@ class ModInt < Numeric
 
   def of_val(val)
     raise ArgumentError unless val.kind_of? Integer
-    x = dup
-    x.val = val % @mod
-    x
+    ModInt.raw(val % @mod, @mod, @is_prime)
   end
 end
 

--- a/src/modint.rb
+++ b/src/modint.rb
@@ -118,19 +118,13 @@ class ModInt < Numeric
   def **(n)
     n = n.to_i
     raise ArgumentError unless 0 <= n
-    x, r = dup, of_val(1)
-    while 0 < n
-      r.mul! x if (n & 1) == 1
-      x.mul! x
-      n >>= 1
-    end
-    r
+    of_val(@val.pow(n, @mod))
   end
 
   def inv
     if @is_prime
       raise RangeError if 0 == @val
-      self ** (@mod - 2)
+      of_val(@val.pow(@mod - 2, @mod))
     else
       g, x = ModInt.inv_gcd(@val, @mod)
       raise RangeError unless 1 == g
@@ -204,6 +198,6 @@ class String
   def to_modint(mod = nil)
     ModInt.new(to_i, mod)
   end
-  
+
   alias to_m to_modint
 end

--- a/src/modint.rb
+++ b/src/modint.rb
@@ -158,7 +158,7 @@ class ModInt < Numeric
   end
 
   def dup
-    Object.instance_method(:dup).bind(self).call
+    ModInt.raw(@val, @mod, @is_prime)
   end
 
   def to_s

--- a/src/modint.rb
+++ b/src/modint.rb
@@ -2,7 +2,7 @@ class ModInt < Numeric
   class << self
     def set_mod(mod)
       raise ArgumentError unless mod.kind_of? Integer and 1 <= mod
-      @@mod, @@bt, @@is_prime = mod, Barrett.new(mod), ModInt.prime?(mod)
+      @@mod, @@is_prime = mod, ModInt.prime?(mod)
     end
 
     def mod=(mod)
@@ -64,11 +64,11 @@ class ModInt < Numeric
     val = 0 if false == val
     raise ArgumentError unless val.kind_of? Integer
     if mod
-      bt, is_prime = Barrett.new(mod), ModInt.prime?(mod)
+      is_prime = ModInt.prime?(mod)
     else
-      mod, bt, is_prime = @@mod, @@bt, @@is_prime
+      mod, is_prime = @@mod, @@is_prime
     end
-    @val, @mod, @is_prime, @bt = val % mod, mod, is_prime, bt
+    @val, @mod, @is_prime = val % mod, mod, is_prime
   end
 
   def inc!
@@ -85,8 +85,7 @@ class ModInt < Numeric
 
   def add!(other)
     other = of_val(other) unless other.kind_of? ModInt
-    @val += other.to_i
-    @val -= @mod if @val >= @mod
+    @val = (@val + other.to_i) % @mod
     return self
   end
 
@@ -98,7 +97,7 @@ class ModInt < Numeric
 
   def mul!(other)
     other = of_val(other) unless other.kind_of? ModInt
-    @val = @bt.mul(@val, other.to_i)
+    @val = @val * other.to_i % @mod
     return self
   end
 
@@ -182,24 +181,6 @@ class ModInt < Numeric
     x = dup
     x.val = val % @mod
     return x
-  end
-
-  class Barrett
-    FULL64 = 0xffffffffffffffff
-
-    def initialize(m)
-      @umod, @im = m, FULL64 / m + 1
-    end
-
-    attr_reader :umod
-
-    def mul(a, b)
-      z = a * b & FULL64
-      x = z * @im >> 64 & FULL64
-      v = z - x * @umod & FULL64
-      v += @umod if @umod <= v
-      return v
-    end
   end
 end
 

--- a/src/modint.rb
+++ b/src/modint.rb
@@ -17,6 +17,7 @@ class ModInt < Numeric
   alias to_i val
 
   def self.raw(val, mod = @@mod, is_prime = false)
+    raise ArgumentError unless val.kind_of? Integer
     x = allocate
     x.val, x.mod, x.is_prime = val, mod, is_prime
     return x
@@ -134,9 +135,14 @@ class ModInt < Numeric
     return Object.instance_method(:dup).bind(self).call
   end
 
+  def inspect
+    "#{val} mod #{mod}"
+  end
+
   private
 
   def of_val(val)
+    raise ArgumentError unless val.kind_of? Integer
     x = dup
     x.val = val % @mod
     return x

--- a/test/modint_test.rb
+++ b/test/modint_test.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+require 'minitest'
+require 'minitest/autorun'
+
+require_relative '../src/modint.rb'
+
+class ModIntTest < Minitest::Test
+  def test_add_sub
+    ns = [2, 100, 0, 1000, -1]
+    mods = [17, 10**9 + 7, 10, 2**16, 3]
+    ys = [0, 1, 10, 27, ModInt.new(5, 3), 10000000, 128, 2357, -23, -100000, 10**100]
+    ns.each do |n|
+      mods.each do |mod|
+        x = ModInt.new(n, mod)
+        ys.each do |y|
+          ac = (x.to_i + y.to_i) % x.mod
+          wj = (x + y).to_i
+          p [x.to_i, y.to_i, x.mod, ac, wj]
+          assert_equal ac, wj
+
+          ac = (x.to_i - y.to_i) % x.mod
+          wj = (x - y).to_i
+          p [x.to_i, y.to_i, x.mod, ac, wj]
+          assert_equal ac, wj
+        end
+      end
+    end
+  end
+
+  def test_mul
+    ns = [2, 100, 0, 1000, -1]
+    mods = [17, 10**9 + 7, 10, 2**16, 3]
+    ys = [0, 1, 10, 27, ModInt.new(5, 3), 10000000, 128, 2357, -23, -100000, 10**100]
+    ns.each do |n|
+      mods.each do |mod|
+        x = ModInt.new(n, mod)
+        ys.each do |y|
+          ac = (x.to_i * y.to_i) % x.mod
+          wj = (x * y).to_i
+          assert_equal ac, wj
+        end
+      end
+    end
+  end
+
+  def test_pow
+    ns = [2, 100, 0, 1000, -1]
+    mods = [17, 10**9 + 7, 10, 2**16, 3]
+    ys = [0, 1, 10, 27, ModInt.new(5, 3), 1000, 128, 2357]
+    ns.each do |n|
+      mods.each do |mod|
+        x = ModInt.new(n, mod)
+        ys.each do |y|
+          ac = x.to_i.pow(y.to_i, x.mod)
+          wj = (x ** y).to_i
+          assert_equal ac, wj
+        end
+      end
+    end
+  end
+end

--- a/test/modint_test.rb
+++ b/test/modint_test.rb
@@ -10,9 +10,9 @@ class ModIntTest < Minitest::Test
   def test_add_sub
     ns = [2, 100, 0, 1000, -1]
     mods = [17, 119 * 2**23 + 1, 10**9 + 7, 10, 2**16, 3]
-    ys = [0, 1, 10, 27, ModInt[5, 3], 10000000, 128, 2357, -23, -100000, 10**100]
+    ys = [0, 1, 10, 27, ModInt(5, 3), 10000000, 128, 2357, -23, -100000, 10**100]
     ns.product(mods) do |(n, mod)|
-      x = ModInt[n, mod]
+      x = ModInt(n, mod)
       ys.each do |y|
         ac = (x.to_i + y.to_i) % x.mod
         wj = (x + y).to_i
@@ -28,9 +28,9 @@ class ModIntTest < Minitest::Test
   def test_mul
     ns = [2, 100, 0, 1000, -1]
     mods = [17, 119 * 2**23 + 1, 10**9 + 7, 10, 2**16, 3]
-    ys = [0, 1, 10, 27, ModInt[5, 3], 10000000, 128, 2357, -23, -100000, 10**100]
+    ys = [0, 1, 10, 27, ModInt(5, 3), 10000000, 128, 2357, -23, -100000, 10**100]
     ns.product(mods) do |(n, mod)|
-      x = ModInt[n, mod]
+      x = ModInt(n, mod)
       ys.each do |y|
         ac = (x.to_i * y.to_i) % x.mod
         wj = (x * y).to_i
@@ -42,9 +42,9 @@ class ModIntTest < Minitest::Test
   def test_pow
     ns = [2, 100, 0, 1000, -1]
     mods = [17, 119 * 2**23 + 1, 10**9 + 7, 10, 2**16, 3]
-    ys = [0, 1, 10, 27, ModInt[5, 3], 1000, 128, 2357]
+    ys = [0, 1, 10, 27, ModInt(5, 3), 1000, 128, 2357]
     ns.product(mods) do |(n, mod)|
-      x = ModInt[n, mod]
+      x = ModInt(n, mod)
       ys.each do |y|
         ac = x.to_i.pow(y.to_i, x.mod)
         wj = (x ** y).to_i
@@ -56,8 +56,8 @@ class ModIntTest < Minitest::Test
   def test_inv_div
     ns = [1, 2, 3, 4, 2357, 2**64]
     mods = [5, 17, 119 * 2**23 + 1, 10**9 + 7]
-    xs = [ModInt[2, 125], ModInt[3, 65536], ModInt[20, 111111], ModInt[99, 100]]
-    xs += ns.product(mods).map { |(n, mod)| ModInt[n, mod] }
+    xs = [ModInt(2, 125), ModInt(3, 65536), ModInt(20, 111111), ModInt(99, 100)]
+    xs += ns.product(mods).map { |(n, mod)| ModInt(n, mod) }
     ys = [0, 1, 10, 27, 1000, 128, 2357]
     xs.each do |x|
       ac = x.to_i.to_bn.mod_inverse(x.mod)

--- a/test/modint_test.rb
+++ b/test/modint_test.rb
@@ -59,15 +59,22 @@ class ModIntTest < Minitest::Test
     end
   end
 
-  def test_inv
+  def test_inv_div
     xs = [ModInt[2, 125], ModInt[3, 65536], ModInt[20, 111111], ModInt[99, 100]]
     ns = [1, 2, 3, 4, 2357, 2**64]
     mods = [5, 17, 119 * 2**23 + 1, 10**9 + 7]
+    ys = [0, 1, 10, 27, 1000, 128, 2357]
     ns.product(mods) { |(n, mod)| xs << ModInt[n, mod] }
     xs.each do |x|
       ac = x.to_i.to_bn.mod_inverse(x.mod)
       wj = x.inv.to_i
       assert_equal ac, wj
+
+      ys.each do |y|
+        ac = (y.to_i * x.to_i.to_bn.mod_inverse(x.mod)).to_i % x.mod
+        wj = (y / x).to_i
+        assert_equal ac, wj
+      end
     end
   end
 end

--- a/test/modint_test.rb
+++ b/test/modint_test.rb
@@ -2,26 +2,25 @@
 
 require 'minitest'
 require 'minitest/autorun'
+require 'openssl'
 
 require_relative '../src/modint.rb'
 
 class ModIntTest < Minitest::Test
   def test_add_sub
     ns = [2, 100, 0, 1000, -1]
-    mods = [17, 10**9 + 7, 10, 2**16, 3]
-    ys = [0, 1, 10, 27, ModInt.new(5, 3), 10000000, 128, 2357, -23, -100000, 10**100]
+    mods = [17, 119 * 2**23 + 1, 10**9 + 7, 10, 2**16, 3]
+    ys = [0, 1, 10, 27, ModInt[5, 3], 10000000, 128, 2357, -23, -100000, 10**100]
     ns.each do |n|
       mods.each do |mod|
-        x = ModInt.new(n, mod)
+        x = ModInt[n, mod]
         ys.each do |y|
           ac = (x.to_i + y.to_i) % x.mod
           wj = (x + y).to_i
-          p [x.to_i, y.to_i, x.mod, ac, wj]
           assert_equal ac, wj
 
           ac = (x.to_i - y.to_i) % x.mod
           wj = (x - y).to_i
-          p [x.to_i, y.to_i, x.mod, ac, wj]
           assert_equal ac, wj
         end
       end
@@ -30,11 +29,11 @@ class ModIntTest < Minitest::Test
 
   def test_mul
     ns = [2, 100, 0, 1000, -1]
-    mods = [17, 10**9 + 7, 10, 2**16, 3]
-    ys = [0, 1, 10, 27, ModInt.new(5, 3), 10000000, 128, 2357, -23, -100000, 10**100]
+    mods = [17, 119 * 2**23 + 1, 10**9 + 7, 10, 2**16, 3]
+    ys = [0, 1, 10, 27, ModInt[5, 3], 10000000, 128, 2357, -23, -100000, 10**100]
     ns.each do |n|
       mods.each do |mod|
-        x = ModInt.new(n, mod)
+        x = ModInt[n, mod]
         ys.each do |y|
           ac = (x.to_i * y.to_i) % x.mod
           wj = (x * y).to_i
@@ -46,17 +45,29 @@ class ModIntTest < Minitest::Test
 
   def test_pow
     ns = [2, 100, 0, 1000, -1]
-    mods = [17, 10**9 + 7, 10, 2**16, 3]
-    ys = [0, 1, 10, 27, ModInt.new(5, 3), 1000, 128, 2357]
+    mods = [17, 119 * 2**23 + 1, 10**9 + 7, 10, 2**16, 3]
+    ys = [0, 1, 10, 27, ModInt[5, 3], 1000, 128, 2357]
     ns.each do |n|
       mods.each do |mod|
-        x = ModInt.new(n, mod)
+        x = ModInt[n, mod]
         ys.each do |y|
           ac = x.to_i.pow(y.to_i, x.mod)
           wj = (x ** y).to_i
           assert_equal ac, wj
         end
       end
+    end
+  end
+
+  def test_inv
+    xs = [ModInt[2, 125], ModInt[3, 65536], ModInt[20, 111111], ModInt[99, 100]]
+    ns = [1, 2, 3, 4, 2357, 2**64]
+    mods = [5, 17, 119 * 2**23 + 1, 10**9 + 7]
+    ns.product(mods) { |(n, mod)| xs << ModInt[n, mod] }
+    xs.each do |x|
+      ac = x.to_i.to_bn.mod_inverse(x.mod)
+      wj = x.inv.to_i
+      assert_equal ac, wj
     end
   end
 end

--- a/test/modint_test.rb
+++ b/test/modint_test.rb
@@ -11,18 +11,16 @@ class ModIntTest < Minitest::Test
     ns = [2, 100, 0, 1000, -1]
     mods = [17, 119 * 2**23 + 1, 10**9 + 7, 10, 2**16, 3]
     ys = [0, 1, 10, 27, ModInt[5, 3], 10000000, 128, 2357, -23, -100000, 10**100]
-    ns.each do |n|
-      mods.each do |mod|
-        x = ModInt[n, mod]
-        ys.each do |y|
-          ac = (x.to_i + y.to_i) % x.mod
-          wj = (x + y).to_i
-          assert_equal ac, wj
+    ns.product(mods) do |(n, mod)|
+      x = ModInt[n, mod]
+      ys.each do |y|
+        ac = (x.to_i + y.to_i) % x.mod
+        wj = (x + y).to_i
+        assert_equal ac, wj
 
-          ac = (x.to_i - y.to_i) % x.mod
-          wj = (x - y).to_i
-          assert_equal ac, wj
-        end
+        ac = (x.to_i - y.to_i) % x.mod
+        wj = (x - y).to_i
+        assert_equal ac, wj
       end
     end
   end
@@ -31,14 +29,12 @@ class ModIntTest < Minitest::Test
     ns = [2, 100, 0, 1000, -1]
     mods = [17, 119 * 2**23 + 1, 10**9 + 7, 10, 2**16, 3]
     ys = [0, 1, 10, 27, ModInt[5, 3], 10000000, 128, 2357, -23, -100000, 10**100]
-    ns.each do |n|
-      mods.each do |mod|
-        x = ModInt[n, mod]
-        ys.each do |y|
-          ac = (x.to_i * y.to_i) % x.mod
-          wj = (x * y).to_i
-          assert_equal ac, wj
-        end
+    ns.product(mods) do |(n, mod)|
+      x = ModInt[n, mod]
+      ys.each do |y|
+        ac = (x.to_i * y.to_i) % x.mod
+        wj = (x * y).to_i
+        assert_equal ac, wj
       end
     end
   end
@@ -47,24 +43,22 @@ class ModIntTest < Minitest::Test
     ns = [2, 100, 0, 1000, -1]
     mods = [17, 119 * 2**23 + 1, 10**9 + 7, 10, 2**16, 3]
     ys = [0, 1, 10, 27, ModInt[5, 3], 1000, 128, 2357]
-    ns.each do |n|
-      mods.each do |mod|
-        x = ModInt[n, mod]
-        ys.each do |y|
-          ac = x.to_i.pow(y.to_i, x.mod)
-          wj = (x ** y).to_i
-          assert_equal ac, wj
-        end
+    ns.product(mods) do |(n, mod)|
+      x = ModInt[n, mod]
+      ys.each do |y|
+        ac = x.to_i.pow(y.to_i, x.mod)
+        wj = (x ** y).to_i
+        assert_equal ac, wj
       end
     end
   end
 
   def test_inv_div
-    xs = [ModInt[2, 125], ModInt[3, 65536], ModInt[20, 111111], ModInt[99, 100]]
     ns = [1, 2, 3, 4, 2357, 2**64]
     mods = [5, 17, 119 * 2**23 + 1, 10**9 + 7]
+    xs = [ModInt[2, 125], ModInt[3, 65536], ModInt[20, 111111], ModInt[99, 100]]
+    xs += ns.product(mods).map { |(n, mod)| ModInt[n, mod] }
     ys = [0, 1, 10, 27, 1000, 128, 2357]
-    ns.product(mods) { |(n, mod)| xs << ModInt[n, mod] }
     xs.each do |x|
       ac = x.to_i.to_bn.mod_inverse(x.mod)
       wj = x.inv.to_i

--- a/test/modint_test.rb
+++ b/test/modint_test.rb
@@ -83,4 +83,13 @@ class ModIntTest < Minitest::Test
       assert_equal x.to_i % 17, x.to_modint(17).to_i
     end
   end
+
+  def test_output
+    ModInt.mod = 10**9 + 7
+    testcases = [[10, "10"], [-1, "1000000006"], [100000000000000, "999300007"], [1000000007, "0"]]
+    testcases.each do |(n, ac)|
+      assert_output("#{ac} mod #{ModInt.mod}\n") { p ModInt(n) }
+      assert_output("#{ac}\n") { puts ModInt(n) }
+    end
+  end
 end

--- a/test/modint_test.rb
+++ b/test/modint_test.rb
@@ -71,4 +71,16 @@ class ModIntTest < Minitest::Test
       end
     end
   end
+
+  def test_to_modint
+    ModInt.mod = 10**9 + 7
+    testcases = ["10", "100000000000000000", "1000000007", 123]
+    testcases.each do |x|
+      ac = x.to_i % ModInt.mod
+      assert_equal ac, x.to_modint.to_i
+      assert_equal ac, x.to_m.to_i
+
+      assert_equal x.to_i % 17, x.to_modint(17).to_i
+    end
+  end
 end


### PR DESCRIPTION
変更点
* `new` の第２引数でmodを指定できます
* 自己代入演算子の名前を変えています ( `++` → `inc!` , `--` → `dec!` , `+=` → `add!` , `-=` → `sub!` , `*=` → `mul!` , `/=` → `div!` )
* 整数との演算のために `Numeric` クラスを継承し、 `ModInt#coerce` をオーバーロードしています
* 利便性のため定義したメソッドがあります
  * `new`: `Kernel#ModInt`
  * ModInt への変換: `Integer#to_modint` `Integer#to_m` `String#to_modint` `String#to_m`
  * ModInt からの変換: `ModInt#to_s` `ModInt#inspect` `ModInt#to_i`
  * デフォルトの mod: `ModInt.mod=` `ModInt.mod` (`ModInt.set_mod` も利用できます)
  * 素数判定: `ModInt.prime?`
  * 拡張ユークリッドによる逆元の計算: `ModInt.inv_gcd`
* 実装
  * `internal::` 系のメソッドは private な特異メソッドとして定義しています
  * Barrett乗算は使用していません
  * 値を表すインスタンス変数は `@val` です

テストした問題
* [ABC178 C - Ubiquity](https://atcoder.jp/contests/abc178/submissions/16968134) (65 ms)
* [ABC055 B - Training Camp](https://atcoder.jp/contests/abc055/submissions/16968113) (88 ms)
* [ARC009 C - 高橋君、24歳](https://atcoder.jp/contests/arc009/submissions/16947785) (1150 ms) (初版は kotatsugame さんによります)