### PR TITLE
Fix NameError in Segtree#get

### DIFF
--- a/src/segtree.rb
+++ b/src/segtree.rb
@@ -27,8 +27,8 @@ class Segtree
     1.upto(@log) { |i| update(q >> i) }
   end
 
-  def get(q)
-    @d[@leaf_size + q]
+  def get(pos)
+    @d[@leaf_size + pos]
   end
 
   def prod(l, r)

--- a/src/segtree.rb
+++ b/src/segtree.rb
@@ -28,7 +28,7 @@ class Segtree
   end
 
   def get(q)
-    d[leaf_size + q]
+    @d[@leaf_size + q]
   end
 
   def prod(l, r)

--- a/test/segtree_test.rb
+++ b/test/segtree_test.rb
@@ -15,6 +15,7 @@ class SegtreeTest < Minitest::Test
     assert_equal 3, st.prod(1 - 1, 5)
     assert_equal 3, st.max_right(2 - 1) { |v| v < 3 } + 1
     st.set(3 - 1, 1)
+    assert_equal 2, st.get(1)
     assert_equal 2, st.prod(2 - 1, 4)
     assert_equal 6, st.max_right(1 - 1) { |v| v < 3 } + 1
   end


### PR DESCRIPTION
おそらく typo で、インスタンス変数のかわりにローカル変数を参照していたので修正しました。
ついでに、仮引数名も工夫の余地があるのではと思って変更しました。