### PR TITLE
Destructive chage on `FenwickTree` / Add Document(ja) e.t.c.

### DIFF
--- a/document_ja/fenwick_tree.md
+++ b/document_ja/fenwick_tree.md
@@ -1,0 +1,62 @@
+# Fenwick Tree
+
+**別名** BIT(Binary Indexed Tree)
+
+長さ`N` の配列に対し、
+
+- 要素の`1`点変更
+- 区間の要素の総和
+
+を`O(logN)`で求めることが出来るデータ構造です。
+
+## コンストラクタ
+
+```rb
+fw = FenwickTree.new(arg)
+```
+
+引数は`Integer`または`Array`です。
+
+1. 引数が`Integer`クラスの`n`のとき、長さ`n`の全ての要素が`0`で初期化された配列を作ります。 
+2. 引数が長さ`n`の`Array`クラスの配列`a`のとき、`a`で初期化された配列を作ります。
+
+
+配列の添字は、0-based indexです。
+ 
+**計算量** 引数が`Integer`オブジェクトのとき`O(n)`で、引数が`Array`オブジェクトのとき`O(n log(n))`です。
+
+## add(pos, x)
+
+```rb
+fw.add(pos, x)
+```
+
+`a[pos] += x`を行います。
+
+`pos`は、0-based indexです。
+
+**計算量** `O(logn)`
+
+## sum(l, r) ->Integer
+
+```rb
+fw.sum(l, r)
+```
+
+`a[l] + a[l - 1] + ... + a[r - 1]`を返します。
+
+引数は、半開区間です。
+
+実装として、内部で`_sum(r) - _sum(l)`を返しています。
+
+**計算量** `O(logn)`
+
+## _sum(pos) -> Integer
+
+```rb
+fw._sum(pos)
+```
+
+`a[0] + a[1] + ... + a[pos - 1]`を返します。
+
+**計算量** `O(logn)`

--- a/document_ja/fenwick_tree.md
+++ b/document_ja/fenwick_tree.md
@@ -20,10 +20,9 @@ fw = FenwickTree.new(arg)
 1. 引数が`Integer`クラスの`n`のとき、長さ`n`の全ての要素が`0`で初期化された配列を作ります。 
 2. 引数が長さ`n`の`Array`クラスの配列`a`のとき、`a`で初期化された配列を作ります。
 
-
 配列の添字は、0-based indexです。
  
-**計算量** 引数が`Integer`オブジェクトのとき`O(n)`で、引数が`Array`オブジェクトのとき`O(n log(n))`です。
+**計算量** `O(n)` (引数が`Array`でも同じです)
 
 ## add(pos, x)
 
@@ -35,6 +34,7 @@ fw.add(pos, x)
 
 `pos`は、0-based indexです。
 
+**制約** `0 ≦　pos < n`
 **計算量** `O(logn)`
 
 ## sum(l, r) ->Integer
@@ -49,6 +49,7 @@ fw.sum(l, r)
 
 実装として、内部で`_sum(r) - _sum(l)`を返しています。
 
+**制約** `0 ≦　l ≦ r ≦ n`
 **計算量** `O(logn)`
 
 ## _sum(pos) -> Integer
@@ -60,3 +61,14 @@ fw._sum(pos)
 `a[0] + a[1] + ... + a[pos - 1]`を返します。
 
 **計算量** `O(logn)`
+
+## Verified
+
+[B \- Fenwick Tree](https://atcoder.jp/contests/practice2/tasks/practice2_b)
+https://atcoder.jp/contests/practice2/submissions/17074108 (1272ms)
+
+## 開発者、内部実装を読みたい人向け
+
+本家ACLライブラリの実装は、内部の配列も0-based indexですが、
+
+本ライブラリは定数倍改善のため、内部の配列への添字が1-based indexです。

--- a/document_ja/fenwick_tree.md
+++ b/document_ja/fenwick_tree.md
@@ -65,6 +65,7 @@ fw._sum(pos)
 ## Verified
 
 [B \- Fenwick Tree](https://atcoder.jp/contests/practice2/tasks/practice2_b)
+
 https://atcoder.jp/contests/practice2/submissions/17074108 (1272ms)
 
 ## 開発者、内部実装を読みたい人向け

--- a/src/fenwick_tree.rb
+++ b/src/fenwick_tree.rb
@@ -2,12 +2,19 @@
 
 # Fenwick Tree
 class FenwickTree
-  def initialize(arg)
+  attr_reader :data, :size
+
+  def initialize(arg = 0)
     case arg
     when Array
       @size = arg.size
-      @data = Array.new(@size + 1, 0)
-      arg.each.with_index(1) { |e, i| add(i, e) }
+      @data = [0].concat(arg)
+      (1 ... @size).each do |i|
+        up = i + (i & -i)
+        next if up > @size
+
+        @data[up] += @data[i]
+      end
     when Integer
       @size = arg
       @data = Array.new(@size + 1, 0)
@@ -17,6 +24,7 @@ class FenwickTree
   end
 
   def add(i, x)
+    i += 1
     while i <= @size
       @data[i] += x
       i += (i & -i)
@@ -38,4 +46,5 @@ class FenwickTree
 end
 
 FeTree            = FenwickTree
+Fetree            = FenwickTree
 BinaryIndexedTree = FenwickTree

--- a/test/example/fenwick_tree_practice.rb
+++ b/test/example/fenwick_tree_practice.rb
@@ -11,7 +11,7 @@ q.times do
   t, u, v = gets.split.map(&:to_i)
 
   if t == 0
-    ft.add(u + 1, v)
+    ft.add(u, v)
   else
     puts ft.sum(u, v)
   end

--- a/test/fenwick_tree_test.rb
+++ b/test/fenwick_tree_test.rb
@@ -13,8 +13,44 @@ class FenwickTreeTest < Minitest::Test
     assert_equal 15, ft.sum(0, 5)
     assert_equal 7, ft.sum(2, 4)
 
-    ft.add(3 + 1, 10)
+    ft.add(3, 10)
     assert_equal 25, ft.sum(0, 5)
     assert_equal 6, ft.sum(0, 3)
+  end
+
+  def test_empty
+    fw = FenwickTree.new
+    assert_equal 0, fw.sum(0, 0)
+  end
+
+  def test_zero
+    fw = FenwickTree.new(0)
+    assert_equal 0, fw.sum(0, 0)
+  end
+
+  def test_naive
+    (1 .. 50).each do |n|
+      fw = FenwickTree.new(n)
+      n.times { |i| fw.add(i, i * i) }
+      (0 .. n).each do |l|
+        (l .. n).each do |r|
+          sum = 0
+          (l ... r).each { |i| sum += i * i }
+          assert_equal sum, fw.sum(l, r)
+        end
+      end
+    end
+  end
+
+  def test_init
+    n = 100
+    a = Array.new(n) { rand(1..n) }
+
+    fwa = FenwickTree.new(a)
+
+    fwi = FenwickTree.new(n)
+    a.each_with_index { |e, i| fwi.add(i, e) }
+
+    assert_equal fwi.data, fwa.data
   end
 end


### PR DESCRIPTION
# 変更内容について

## addメソッドの破壊的変更
`add`メソッドのみが1-based indexとなっており、本家の仕様とも異なっていたため、これを変更します。

## 配列を引数とした初期化の計算量改善`O(n log n)` -> `O(n)`
計算量を改善しました。

## テストを追加
テストが少なかったため、本家ACLに合わせて追加しています。
また、配列の初期化が正しいことを確かめるために、1つずつ追加したときと同じになることを確かめています。

## ドキュメント(日本語版)の追加

基本的には、元のコードが本家ACLと同じなので、全体としてドキュメントも同じような形です。
0-based indexと1-based indexの2つの派閥があるみたいですが、実装を0-based indexに合わせおり、その旨を強調。
まあ、引数が1つの`_sum(pos)`メソッドについての説明も加えています。