### PR TITLE
use `bit_length` for speed, instead of `ceil_pow2`

### DIFF
--- a/src/segtree.rb
+++ b/src/segtree.rb
@@ -14,7 +14,7 @@ class Segtree
     @op = proc(&block)
 
     @n = v.size
-    @log = ceil_pow2(@n)
+    @log = (@n - 1).bit_length
     @leaf_size = 1 << @log
     @d = Array.new(@leaf_size * 2) { e }
     v.each_with_index { |v_i, i| @d[@leaf_size + i] = v_i }
@@ -105,9 +105,3 @@ end
 
 SegTree     = Segtree
 SegmentTree = Segtree
-
-def ceil_pow2(n)
-  x = 0
-  x += 1 while (1 << x) < n
-  x
-end


### PR DESCRIPTION
verified: https://atcoder.jp/contests/practice2/submissions/17016886 (896ms)

```rb
require 'benchmark'

n = 10**5
puts "n = #{n}"

def ceil_pow2(n)
  x = 0
  x += 1 while (1 << x) < n
  x
end

Benchmark.bm 10 do |r|
  r1 = r.report 'bit_length' do
    a = (1..n).map { |i| (i -1).bit_length }
  end

  r2 = r.report 'ceil_pow2' do
    b = (1..n).map { |i| ceil_pow2(i) }
  end
end

# n = 100000
#                  user     system      total        real
# bit_length   0.006636   0.000243   0.006879 (  0.006877)
# ceil_pow2    0.061365   0.000593   0.061958 (  0.062107)
```

本家ACLの実装を真似た`ceil_pow2`関数を使うよりも、`bit_length`を使った方が速そいみたいです。
AtCoderの提出で時間を計測すると896ms - 948msとブレがありますが、Rubyの中で現時点での最速タイムがでて平均的に速いはずです。
また、速くなっただけでなく、もともとあったメソッドを使うのでコードが軽くなって締まりが良いです。