### PR TITLE
Improve ModInt and add easy tests

### DIFF
--- a/src/modint.rb
+++ b/src/modint.rb
@@ -125,6 +125,10 @@ class ModInt < Numeric
     of_val(@val.pow(n, @mod))
   end
 
+  def pow(other)
+    of_val(@val.to_i.pow(other, @mod))
+  end
+
   def inv
     of_val(inv_internal(@val))
   end

--- a/src/modint.rb
+++ b/src/modint.rb
@@ -1,7 +1,11 @@
+# frozen_string_literal: true
+
+# ModInt
 class ModInt < Numeric
   class << self
     def set_mod(mod)
-      raise ArgumentError unless mod.kind_of? Integer and 1 <= mod
+      raise ArgumentError unless mod.is_a? Integer and 1 <= mod
+
       @@mod, @@is_prime = mod, ModInt.prime?(mod)
     end
 
@@ -14,7 +18,8 @@ class ModInt < Numeric
     end
 
     def raw(val, mod = @@mod, is_prime = false)
-      raise ArgumentError unless val.kind_of? Integer
+      raise ArgumentError unless val.is_a? Integer
+
       x = allocate
       x.val, x.mod, x.is_prime = val, mod, is_prime
       x
@@ -24,6 +29,7 @@ class ModInt < Numeric
       return false if n <= 1
       return true if n == 2 or n == 7 or n == 61
       return false if (n & 1) == 0
+
       d = n - 1
       d >>= 1 while (d & 1) == 0
       [2, 7, 61].each do |a|
@@ -41,6 +47,7 @@ class ModInt < Numeric
     def inv_gcd(a, b)
       a %= b
       return [b, 0] if 0 == a
+
       s, t = b, a
       m0, m1 = 0, 1
       while 0 != t
@@ -62,7 +69,8 @@ class ModInt < Numeric
   def initialize(val = 0, mod = nil)
     val = 1 if true == val
     val = 0 if false == val
-    raise ArgumentError unless val.kind_of? Integer
+    raise ArgumentError unless val.is_a? Integer
+
     if mod
       is_prime = ModInt.prime?(mod)
     else
@@ -110,9 +118,10 @@ class ModInt < Numeric
     ModInt.raw(@mod - @val, @mod, @is_prime)
   end
 
-  def **(n)
-    n = n.to_i
+  def **(other)
+    n = other.to_i
     raise ArgumentError unless 0 <= n
+
     of_val(@val.pow(n, @mod))
   end
 
@@ -140,12 +149,12 @@ class ModInt < Numeric
     dup.div! other
   end
 
-  def ==(rhs)
-    @val == rhs.val
+  def ==(other)
+    @val == other.to_i
   end
 
-  def !=(rhs)
-    @val != rhs.val
+  def !=(other)
+    @val != other.to_i
   end
 
   def dup
@@ -163,17 +172,20 @@ class ModInt < Numeric
   private
 
   def of_val(val)
-    raise ArgumentError unless val.kind_of? Integer
+    raise ArgumentError unless val.is_a? Integer
+
     ModInt.raw(val % @mod, @mod, @is_prime)
   end
 
   def inv_internal(a)
     if @is_prime
       raise RangeError if 0 == a
+
       a.pow(@mod - 2, @mod)
     else
       g, x = ModInt.inv_gcd(a, @mod)
       raise RangeError unless 1 == g
+
       x
     end
   end

--- a/test/modint_test.rb
+++ b/test/modint_test.rb
@@ -37,6 +37,7 @@ class ModIntTest < Minitest::Test
     assert_equal 10, a # 10 mod 11
 
     assert_equal 5, ModInt(2)**4 # 5 mod 11
+    assert_equal 5, ModInt(2).pow(4) # 5 mod 11
 
     assert_output("10\n") { puts a } # 10
     assert_output("10 mod 11\n") { p a } # 10 mod 11

--- a/test/modint_test.rb
+++ b/test/modint_test.rb
@@ -6,11 +6,83 @@ require 'openssl'
 
 require_relative '../src/modint.rb'
 
+# test ModInt
 class ModIntTest < Minitest::Test
+  def test_example
+    ModInt.set_mod(11) # equals `ModInt.mod = 11`
+    assert_equal 11, ModInt.mod
+
+    a = ModInt(10)
+    b = 3.to_m
+
+    assert_equal 8, -b    # 8 mod 11
+
+    assert_equal 2, a + b # 2 mod 11
+    assert_equal 0, 1 + a # 0 mod 11
+    assert_equal 7, a - b # 7 mod 11
+    assert_equal 4, b - a # 4 mod 11
+
+    assert_equal 8, a * b # 8 mod 11
+    assert_equal 4, b.inv # 4 mod 11
+
+    assert_equal 7, a / b # 7 mod 11
+
+    a += b
+    assert_equal 2, a  #  2 mod 11
+    a -= b
+    assert_equal 10, a # 10 mod 11
+    a *= b
+    assert_equal 8, a  #  8 mod 11
+    a /= b
+    assert_equal 10, a # 10 mod 11
+
+    assert_equal 5, ModInt(2)**4 # 5 mod 11
+
+    assert_output("10\n") { puts a } # 10
+    assert_output("10 mod 11\n") { p a } # 10 mod 11
+
+    assert_equal 11, a.mod # 11
+
+    assert_equal 3, ModInt.raw(3) # 3 mod 11
+  end
+
+  def test_usage
+    ModInt.mod = 11
+    assert_equal 11, ModInt.mod
+
+    assert_equal 4, ModInt.new(4)
+    assert_equal 7, -ModInt.new(4)
+
+    assert_equal 4, ModInt.new(4).to_i
+    assert_equal 7, (-ModInt.new(4)).to_i
+
+    assert ModInt.new(1) != ModInt.new(4)
+    assert ModInt.new(1) == ModInt.new(12)
+
+    ModInt.mod = 998_244_353
+    assert_equal 998_244_353, ModInt.mod
+    assert_equal 3, (ModInt(1) + ModInt(2))
+    assert_equal 3, (1 + ModInt(2))
+    assert_equal 3, (ModInt(1) + 2)
+
+    assert_equal 3, ModInt.mod = 3
+    assert_equal 3, ModInt.mod
+    assert_equal 1, ModInt(2) - ModInt(1)
+    assert_equal 0, ModInt(1) + ModInt(2)
+    assert_equal 0, 1 + ModInt(2)
+    assert_equal 0, ModInt(1) + 2
+
+    ModInt.set_mod(11)
+    assert_equal 11, ModInt.mod
+    assert_equal 4, ModInt(3) * ModInt(5)
+    assert_equal 4, ModInt.new(4)
+    assert_equal 7, -ModInt.new(4)
+  end
+
   def test_add_sub
     ns = [2, 100, 0, 1000, -1]
     mods = [17, 119 * 2**23 + 1, 10**9 + 7, 10, 2**16, 3]
-    ys = [0, 1, 10, 27, ModInt(5, 3), 10000000, 128, 2357, -23, -100000, 10**100]
+    ys = [0, 1, 10, 27, ModInt(5, 3), 10**7, 128, 2357, -23, -10**5, 10**100]
     ns.product(mods) do |(n, mod)|
       x = ModInt(n, mod)
       ys.each do |y|
@@ -28,7 +100,7 @@ class ModIntTest < Minitest::Test
   def test_mul
     ns = [2, 100, 0, 1000, -1]
     mods = [17, 119 * 2**23 + 1, 10**9 + 7, 10, 2**16, 3]
-    ys = [0, 1, 10, 27, ModInt(5, 3), 10000000, 128, 2357, -23, -100000, 10**100]
+    ys = [0, 1, 10, 27, ModInt(5, 3), 10**7, 128, 2357, -23, -10**5, 10**100]
     ns.product(mods) do |(n, mod)|
       x = ModInt(n, mod)
       ys.each do |y|
@@ -47,7 +119,7 @@ class ModIntTest < Minitest::Test
       x = ModInt(n, mod)
       ys.each do |y|
         ac = x.to_i.pow(y.to_i, x.mod)
-        wj = (x ** y).to_i
+        wj = (x**y).to_i
         assert_equal ac, wj
       end
     end
@@ -56,7 +128,7 @@ class ModIntTest < Minitest::Test
   def test_inv_div
     ns = [1, 2, 3, 4, 2357, 2**64]
     mods = [5, 17, 119 * 2**23 + 1, 10**9 + 7]
-    xs = [ModInt(2, 125), ModInt(3, 65536), ModInt(20, 111111), ModInt(99, 100)]
+    xs = [ModInt(2, 125), ModInt(3, 65_536), ModInt(20, 111_111), ModInt(99, 100)]
     xs += ns.product(mods).map { |(n, mod)| ModInt(n, mod) }
     ys = [0, 1, 10, 27, 1000, 128, 2357]
     xs.each do |x|
@@ -86,7 +158,7 @@ class ModIntTest < Minitest::Test
 
   def test_output
     ModInt.mod = 10**9 + 7
-    testcases = [[10, "10"], [-1, "1000000006"], [100000000000000, "999300007"], [1000000007, "0"]]
+    testcases = [[10, "10"], [-1, "1000000006"], [10**14, "999300007"], [10**9 + 7, "0"]]
     testcases.each do |(n, ac)|
       assert_output("#{ac} mod #{ModInt.mod}\n") { p ModInt(n) }
       assert_output("#{ac}\n") { puts ModInt(n) }


### PR DESCRIPTION
`==`と`!=`について、変更があります。
以前までは、`ModInt`と`Integer`の比較ができずエラーとなっていましたが、`val`から`to_i`に変更することで、両者を比較できるようにしました。

```ruby
class ModInt < Numeric
  def !=(rhs)
    @val != rhs.val
  end
end

0.to_m == 0 # Error 
```
↓
```rb
class ModInt < Numeric
  def !=(other)
    @val != other.to_i
  end
end

0.to_m == 0 # true
```

その他、リファクタリングを混ぜ込んじゃっています。
`kind_of?`から`is_a?`に書き換えたのは、デフォルトのRuboCopで何故か警告を貰うのと、短い方がいいと思ったのと、Crystalへの移植を考えたときに`is_a?`は使えたけど`kind_of?`は使えなかったはずだからです。