### PR TITLE
Improve ModInt and test for it and Add example file for it

### DIFF
--- a/src/modint.rb
+++ b/src/modint.rb
@@ -169,7 +169,7 @@ class ModInt < Numeric
   end
 end
 
-def ModInt(val = 0)
+def ModInt(val)
   ModInt.new(val)
 end
 

--- a/src/modint.rb
+++ b/src/modint.rb
@@ -6,7 +6,7 @@ class ModInt < Numeric
     def set_mod(mod)
       raise ArgumentError unless mod.is_a? Integer and 1 <= mod
 
-      @@mod, @@is_prime = mod, ModInt.prime?(mod)
+      $mod, $is_prime = mod, ModInt.prime?(mod)
     end
 
     def mod=(mod)
@@ -14,13 +14,12 @@ class ModInt < Numeric
     end
 
     def mod
-      @@mod
+      $mod
     end
 
     def raw(val)
-      raise ArgumentError unless val.is_a? Integer
       x = allocate
-      x.val = val
+      x.val = val.to_int
       x
     end
 
@@ -66,34 +65,33 @@ class ModInt < Numeric
   alias to_i val
 
   def initialize(val = 0)
-    raise ArgumentError unless val.is_a? Integer
-    @val = val % @@mod
+    @val = val.to_int % $mod
   end
 
   def inc!
     @val += 1
-    @val = 0 if @val == @@mod
+    @val = 0 if @val == $mod
     self
   end
 
   def dec!
-    @val = @@mod if @val == 0
+    @val = $mod if @val == 0
     @val -= 1
     self
   end
 
   def add!(other)
-    @val = (@val + other.to_i) % @@mod
+    @val = (@val + other.to_i) % $mod
     self
   end
 
   def sub!(other)
-    @val = (@val - other.to_i) % @@mod
+    @val = (@val - other.to_i) % $mod
     self
   end
 
   def mul!(other)
-    @val = @val * other.to_i % @@mod
+    @val = @val * other.to_i % $mod
     self
   end
 
@@ -106,18 +104,18 @@ class ModInt < Numeric
   end
 
   def -@
-    ModInt.raw(@@mod - @val)
+    ModInt.raw($mod - @val)
   end
 
   def **(other)
     n = other.to_i
     raise ArgumentError unless 0 <= n
 
-    of_val(@val.pow(n, @@mod))
+    of_val(@val.pow(n, $mod))
   end
 
   def pow(other)
-    of_val(@val.to_i.pow(other, @@mod))
+    of_val(@val.to_i.pow(other, $mod))
   end
 
   def inv
@@ -169,23 +167,22 @@ class ModInt < Numeric
   end
 
   def inspect
-    "#{@val} mod #{@@mod}"
+    "#{@val} mod #{$mod}"
   end
 
   private
 
   def of_val(val)
-    raise ArgumentError unless val.is_a? Integer
-    ModInt.raw(val % @@mod)
+    ModInt.raw(val.to_int % $mod)
   end
 
   def inv_internal(a)
-    if @@is_prime
+    if $is_prime
       raise RangeError, 'no inverse' if 0 == a
 
-      a.pow(@@mod - 2, @@mod)
+      a.pow($mod - 2, $mod)
     else
-      g, x = ModInt.inv_gcd(a, @@mod)
+      g, x = ModInt.inv_gcd(a, $mod)
       raise RangeError, 'no inverse' unless 1 == g
 
       x

--- a/src/modint.rb
+++ b/src/modint.rb
@@ -141,20 +141,12 @@ class ModInt < Numeric
     @val == other.to_i
   end
 
-  def !=(other)
-    @val != other.to_i
-  end
-
   def dup
     ModInt.raw(@val)
   end
 
   def to_int
     @val
-  end
-
-  def zero?
-    @val.zero?
   end
 
   def to_s

--- a/src/modint.rb
+++ b/src/modint.rb
@@ -6,7 +6,8 @@ class ModInt < Numeric
     def set_mod(mod)
       raise ArgumentError unless mod.is_a? Integer and 1 <= mod
 
-      $mod, $is_prime = mod, ModInt.prime?(mod)
+      $_mod = mod
+      $_mod_is_prime = ModInt.prime?(mod)
     end
 
     def mod=(mod)
@@ -14,12 +15,12 @@ class ModInt < Numeric
     end
 
     def mod
-      $mod
+      $_mod
     end
 
     def raw(val)
       x = allocate
-      x.val = val.to_int
+      x.val = val.to_i
       x
     end
 
@@ -65,33 +66,33 @@ class ModInt < Numeric
   alias to_i val
 
   def initialize(val = 0)
-    @val = val.to_int % $mod
+    @val = val.to_i % $_mod
   end
 
   def inc!
     @val += 1
-    @val = 0 if @val == $mod
+    @val = 0 if @val == $_mod
     self
   end
 
   def dec!
-    @val = $mod if @val == 0
+    @val = $_mod if @val == 0
     @val -= 1
     self
   end
 
   def add!(other)
-    @val = (@val + other.to_i) % $mod
+    @val = (@val + other.to_i) % $_mod
     self
   end
 
   def sub!(other)
-    @val = (@val - other.to_i) % $mod
+    @val = (@val - other.to_i) % $_mod
     self
   end
 
   def mul!(other)
-    @val = @val * other.to_i % $mod
+    @val = @val * other.to_i % $_mod
     self
   end
 
@@ -104,22 +105,16 @@ class ModInt < Numeric
   end
 
   def -@
-    ModInt.raw($mod - @val)
+    ModInt.raw($_mod - @val)
   end
 
   def **(other)
-    return 0 if $mod == 1
-
-    ModInt.raw(@val.pow(other, $mod))
+    $_mod == 1 ? 0 : ModInt.raw(@val.pow(other, $_mod))
   end
-
-  def pow(other)
-    return 0 if $mod == 1
-    ModInt.raw(@val.pow(other, $mod))
-  end
+  alias pow **
 
   def inv
-    ModInt.raw(inv_internal(@val) % $mod)
+    ModInt.raw(inv_internal(@val) % $_mod)
   end
 
   def coerce(other)
@@ -167,21 +162,17 @@ class ModInt < Numeric
   end
 
   def inspect
-    "#{@val} mod #{$mod}"
+    "#{@val} mod #{$_mod}"
   end
 
   private
 
   def inv_internal(a)
-    if $is_prime
-      raise RangeError, 'no inverse' if 0 == a
-
-      a.pow($mod - 2, $mod)
+    if $_mod_is_prime
+      a != 0 ? a.pow($_mod - 2, $_mod) : raise(RangeError, 'no inverse')
     else
-      g, x = ModInt.inv_gcd(a, $mod)
-      raise RangeError, 'no inverse' unless 1 == g
-
-      x
+      g, x = ModInt.inv_gcd(a, $_mod)
+      g == 1 ? x : raise(RangeError, 'no inverse')
     end
   end
 end
@@ -190,18 +181,18 @@ def ModInt(val = 0)
   ModInt.new(val)
 end
 
+# Integer
 class Integer
   def to_modint
     ModInt.new(self)
   end
-
   alias to_m to_modint
 end
 
+# String
 class String
   def to_modint
     ModInt.new(to_i)
   end
-
   alias to_m to_modint
 end

--- a/src/modint.rb
+++ b/src/modint.rb
@@ -108,22 +108,22 @@ class ModInt < Numeric
   end
 
   def **(other)
-    n = other.to_i
-    raise ArgumentError unless 0 <= n
+    return 0 if $mod == 1
 
-    of_val(@val.pow(n, $mod))
+    ModInt.raw(@val.pow(other, $mod))
   end
 
   def pow(other)
-    of_val(@val.to_i.pow(other, $mod))
+    return 0 if $mod == 1
+    ModInt.raw(@val.pow(other, $mod))
   end
 
   def inv
-    of_val(inv_internal(@val))
+    ModInt.raw(inv_internal(@val) % $mod)
   end
 
   def coerce(other)
-    [of_val(other), self]
+    [ModInt(other), self]
   end
 
   def +(other)
@@ -171,10 +171,6 @@ class ModInt < Numeric
   end
 
   private
-
-  def of_val(val)
-    ModInt.raw(val.to_int % $mod)
-  end
 
   def inv_internal(a)
     if $is_prime

--- a/test/example/modint.rb
+++ b/test/example/modint.rb
@@ -1,7 +1,9 @@
+# frozen_string_literal: true
+
 require_relative '../../src/modint.rb'
 
 ModInt.set_mod(11)
-ModInt.mod #=> 11
+ModInt.mod # 11
 
 a = ModInt(10)
 b = 3.to_m
@@ -27,8 +29,24 @@ a #  8 mod 11
 a /= b
 a # 10 mod 11
 
+a**2 # 1 mod 11
+a**3 # 10 mod 11
+a.pow(4) # 1 mod 11
+
 ModInt(2)**4 # 5 mod 11
 
-puts a #=> 10
+puts a # 10
 
-ModInt.raw(3) #=> 3 mod 11
+a = ModInt.raw(3) # 3 mod 11
+
+a.zero?    # false
+a.nonzero? # 3 mod 11
+
+a = 11.to_m
+a.zero?    # true
+a.nonzero? # nil
+
+ModInt.mod = 1
+a # 0 mod 1
+a.pow(0) # 0
+a**0 # 0

--- a/test/example/modint.rb
+++ b/test/example/modint.rb
@@ -1,0 +1,34 @@
+require_relative '../../src/modint.rb'
+
+ModInt.set_mod(11)
+ModInt.mod #=> 11
+
+a = ModInt(10)
+b = 3.to_m
+
+-b    # 8 mod 11
+
+a + b # 2 mod 11
+1 + a # 0 mod 11
+a - b # 7 mod 11
+b - a # 4 mod 11
+
+a * b # 8 mod 11
+b.inv # 4 mod 11
+
+a / b #  7 mod 11
+
+a += b
+a #  2 mod 11
+a -= b
+a # 10 mod 11
+a *= b
+a #  8 mod 11
+a /= b
+a # 10 mod 11
+
+ModInt(2)**4 # 5 mod 11
+
+puts a #=> 10
+
+ModInt.raw(3) #=> 3 mod 11

--- a/test/modint_test.rb
+++ b/test/modint_test.rb
@@ -182,12 +182,12 @@ class ModIntTest < Minitest::Test
     # Ruby 2.7.1 may have a bug: i.pow(0, 1) #=> 1 if i is a Integer
     # this returns should be 0
     ModInt.mod = 1
-    assert_equal 0, ModInt(-1).pow(0)
-    assert_equal 0, ModInt(0).pow(0)
-    assert_equal 0, ModInt(1).pow(0)
-    assert_equal 0, ModInt(-1)**0
-    assert_equal 0, ModInt(-1)**0
-    assert_equal 0, ModInt(-1)**0
+    assert_equal 0, ModInt(-1).pow(0), "corner case when modulo is one"
+    assert_equal 0, ModInt(0).pow(0), "corner case when modulo is one"
+    assert_equal 0, ModInt(1).pow(0), "corner case when modulo is one"
+    assert_equal 0, ModInt(-5)**0, "corner case when modulo is one"
+    assert_equal 0, ModInt(0)**0, "corner case when modulo is one"
+    assert_equal 0, ModInt(5)**0, "corner case when modulo is one"
   end
 
   def test_inv_in_the_case_that_mod_is_prime

--- a/test/modint_test.rb
+++ b/test/modint_test.rb
@@ -148,11 +148,10 @@ class ModIntTest < Minitest::Test
   end
 
   def test_pow
-    mods = [1, 2, 3, 10, 17, 2**16, 119 * 2**23 + 1, 10**9 + 7]
     xs = [-6, -2, -1, 0, 1, 2, 6, 100]
     ys = [0, 1, 2, 3, 6, 100]
 
-    mods.each do |mod|
+    @mods.each do |mod|
       ModInt.mod = mod
 
       xs.product(ys) do |(x, y)|

--- a/test/modint_test.rb
+++ b/test/modint_test.rb
@@ -124,10 +124,11 @@ class ModIntTest < Minitest::Test
   end
 
   def test_pow
+    mods = [1, 2, 3, 10, 17, 2**16, 119 * 2**23 + 1, 10**9 + 7]
     xs = [-2, -1, 0, 1, 2, 100, 1000]
     ys = [0, 1, 10, 27, 5, 1000, 128, 2357]
 
-    @mods.each do |mod|
+    mods.each do |mod|
       ModInt.mod = mod
 
       xs.product(ys) do |(x, y)|

--- a/test/modint_test.rb
+++ b/test/modint_test.rb
@@ -8,6 +8,12 @@ require_relative '../src/modint.rb'
 
 # test ModInt
 class ModIntTest < Minitest::Test
+  def setup
+    @mods = [1, 2, 3, 10, 17, 2**16, 119 * 2**23 + 1, 10**9 + 7]
+    @primes = [2, 3, 5, 7, 11, 13, 17, 10**9 + 7]
+    @values = [-10**5, -23, -2, -1, 0, 1, 2, 5, 10, 100, 1000, 27, 128, 2357, 10**7, 10**100]
+  end
+
   def test_example
     ModInt.set_mod(11) # equals `ModInt.mod = 11`
     assert_equal 11, ModInt.mod
@@ -41,8 +47,6 @@ class ModIntTest < Minitest::Test
 
     assert_output("10\n") { puts a } # 10
     assert_output("10 mod 11\n") { p a } # 10 mod 11
-
-    assert_equal 11, a.mod # 11
 
     assert_equal 3, ModInt.raw(3) # 3 mod 11
   end
@@ -80,89 +84,239 @@ class ModIntTest < Minitest::Test
     assert_equal 7, -ModInt.new(4)
   end
 
-  def test_add_sub
-    ns = [2, 100, 0, 1000, -1]
-    mods = [17, 119 * 2**23 + 1, 10**9 + 7, 10, 2**16, 3]
-    ys = [0, 1, 10, 27, ModInt(5, 3), 10**7, 128, 2357, -23, -10**5, 10**100]
-    ns.product(mods) do |(n, mod)|
-      x = ModInt(n, mod)
-      ys.each do |y|
-        ac = (x.to_i + y.to_i) % x.mod
-        wj = (x + y).to_i
-        assert_equal ac, wj
+  def test_add
+    @mods.each do |mod|
+      ModInt.mod = mod
 
-        ac = (x.to_i - y.to_i) % x.mod
-        wj = (x - y).to_i
-        assert_equal ac, wj
+      @values.product(@values) do |(x, y)|
+        expected = (x + y) % mod
+        assert_equal expected, x.to_m + y
+        assert_equal expected, x + y.to_m
+        assert_equal expected, x.to_m + y.to_m
+      end
+    end
+  end
+
+  def test_sub
+    @mods.each do |mod|
+      ModInt.mod = mod
+
+      @values.product(@values) do |(x, y)|
+        expected = (x - y) % mod
+        assert_equal expected, x.to_m - y
+        assert_equal expected, x - y.to_m
+        assert_equal expected, x.to_m - y.to_m
       end
     end
   end
 
   def test_mul
-    ns = [2, 100, 0, 1000, -1]
-    mods = [17, 119 * 2**23 + 1, 10**9 + 7, 10, 2**16, 3]
-    ys = [0, 1, 10, 27, ModInt(5, 3), 10**7, 128, 2357, -23, -10**5, 10**100]
-    ns.product(mods) do |(n, mod)|
-      x = ModInt(n, mod)
-      ys.each do |y|
-        ac = (x.to_i * y.to_i) % x.mod
-        wj = (x * y).to_i
-        assert_equal ac, wj
+    @mods.each do |mod|
+      ModInt.mod = mod
+
+      @values.product(@values) do |(x, y)|
+        expected = (x * y) % mod
+        assert_equal expected, x.to_m * y
+        assert_equal expected, x * y.to_m
+        assert_equal expected, x.to_m * y.to_m
       end
     end
   end
 
   def test_pow
-    ns = [2, 100, 0, 1000, -1]
-    mods = [17, 119 * 2**23 + 1, 10**9 + 7, 10, 2**16, 3]
-    ys = [0, 1, 10, 27, ModInt(5, 3), 1000, 128, 2357]
-    ns.product(mods) do |(n, mod)|
-      x = ModInt(n, mod)
-      ys.each do |y|
-        ac = x.to_i.pow(y.to_i, x.mod)
-        wj = (x**y).to_i
-        assert_equal ac, wj
+    xs = [-2, -1, 0, 1, 2, 100, 1000]
+    ys = [0, 1, 10, 27, 5, 1000, 128, 2357]
+
+    @mods.each do |mod|
+      ModInt.mod = mod
+
+      xs.product(ys) do |(x, y)|
+        expected = (x**y) % mod
+        assert_equal expected, x.to_m**y
+        assert_equal expected, x.to_m.pow(y)
       end
     end
   end
 
-  def test_inv_div
-    ns = [1, 2, 3, 4, 2357, 2**64]
-    mods = [5, 17, 119 * 2**23 + 1, 10**9 + 7]
-    xs = [ModInt(2, 125), ModInt(3, 65_536), ModInt(20, 111_111), ModInt(99, 100)]
-    xs += ns.product(mods).map { |(n, mod)| ModInt(n, mod) }
-    ys = [0, 1, 10, 27, 1000, 128, 2357]
-    xs.each do |x|
-      ac = x.to_i.to_bn.mod_inverse(x.mod)
-      wj = x.inv.to_i
-      assert_equal ac, wj
+  def test_pow_method
+    mods = [2, 3, 10, 17, 2**16, 119 * 2**23 + 1, 10**9 + 7]
+    xs = [-2, -1, 0, 1, 2, 100, 1000]
+    ys = [0, 1, 10, 27, 5, 1000, 128, 2357, 10**9, 10**100]
 
-      ys.each do |y|
-        ac = (y.to_i * x.to_i.to_bn.mod_inverse(x.mod)).to_i % x.mod
-        wj = (y / x).to_i
-        assert_equal ac, wj
+    mods.each do |mod|
+      ModInt.mod = mod
+
+      xs.product(ys) do |(x, y)|
+        expected = x.pow(y, mod)
+        assert_equal expected, x.to_m**y
+        assert_equal expected, x.to_m.pow(y)
       end
     end
   end
 
-  def test_to_modint
-    ModInt.mod = 10**9 + 7
-    testcases = ["10", "100000000000000000", "1000000007", 123]
-    testcases.each do |x|
-      ac = x.to_i % ModInt.mod
-      assert_equal ac, x.to_modint.to_i
-      assert_equal ac, x.to_m.to_i
+  def test_inv_in_the_case_that_mod_is_prime
+    @primes.each do |prime_mod|
+      ModInt.mod = prime_mod
 
-      assert_equal x.to_i % 17, x.to_modint(17).to_i
+      values = Array.new(30) { rand(-10**100...10**100) }
+      values.concat(Array(-6..6))
+      values.each do |value|
+        next if (value % prime_mod).zero?
+
+        expected = value.to_bn.mod_inverse(prime_mod).to_i
+        assert_equal expected, value.to_m.inv
+        assert_equal expected, 1 / value.to_m
+        assert_equal expected, 1.to_m / value
+        assert_equal expected, 1.to_m / value.to_m
+      end
     end
   end
 
-  def test_output
+  def test_inv_in_the_random_mod_case
+    mods = Array.new(30) { rand(2..10**100) }
+    mods.concat(Array(2..30))
+
+    mods.each do |mod|
+      ModInt.mod = mod
+
+      assert_equal 1,  1.to_m.inv
+      assert_equal 1,  1 / 1.to_m
+      assert_equal 1,  1.to_m / 1
+
+      assert_equal mod - 1, (mod - 1).to_m.inv
+      assert_equal mod - 1, 1 / (mod - 1).to_m
+      assert_equal mod - 1, 1.to_m / (mod - 1)
+      assert_equal mod - 1, 1.to_m / (mod - 1).to_m
+    end
+  end
+
+  def test_div_in_the_case_that_mod_is_prime
+    @primes.each do |prime_mod|
+      ModInt.mod = prime_mod
+
+      values = Array.new(30) { rand(-10**100...10**100) }
+      values.concat(Array(-6..6))
+      values.product(values) do |(x, y)|
+        next if (y % prime_mod).zero?
+
+        expected = (x * y.to_bn.mod_inverse(prime_mod).to_i) % prime_mod
+
+        assert_equal expected, x.to_m / y
+        assert_equal expected, x / y.to_m
+        assert_equal expected, x.to_m / y.to_m
+      end
+    end
+  end
+
+  def test_inv_in_the_case_that_mod_is_not_prime
+    mods = { 4 => [1, 3], 6 => [1, 5], 8 => [1, 3, 5, 7], 9 => [2, 4, 7, 8], 10 => [3, 7, 9] }
+    mods.each do |(mod, numbers)|
+      ModInt.mod = mod
+
+      @values.product(numbers) do |(x, y)|
+        expected = (x * y.to_bn.mod_inverse(mod).to_i) % mod
+
+        assert_equal expected, x.to_m / y
+        assert_equal expected, x / y.to_m
+        assert_equal expected, x.to_m / y.to_m
+      end
+    end
+  end
+
+  def test_to_i
+    @mods.each do |mod|
+      ModInt.mod = mod
+
+      @values.each do |value|
+        expected =  value % mod
+        actual   =  value.to_m.to_i
+
+        assert actual.is_a?(Integer)
+        assert_equal expected, actual
+      end
+    end
+  end
+
+  def test_to_int
+    @mods.each do |mod|
+      ModInt.mod = mod
+
+      @values.each do |value|
+        expected =  value % mod
+        actual   =  value.to_m.to_int
+
+        assert actual.is_a?(Integer)
+        assert_equal expected, actual
+      end
+    end
+  end
+
+  def test_zero?
+    @mods.each do |mod|
+      ModInt.mod = mod
+
+      @values.each do |value|
+        expected = (value % mod).zero?
+        actual   =  value.to_m.zero?
+
+        assert_equal expected, actual
+      end
+    end
+  end
+
+  def test_integer_to_modint
     ModInt.mod = 10**9 + 7
-    testcases = [[10, "10"], [-1, "1000000006"], [10**14, "999300007"], [10**9 + 7, "0"]]
-    testcases.each do |(n, ac)|
-      assert_output("#{ac} mod #{ModInt.mod}\n") { p ModInt(n) }
-      assert_output("#{ac}\n") { puts ModInt(n) }
+
+    @values.each do |value|
+      expected = ModInt(value)
+      assert_equal expected, value.to_m
+      assert_equal expected, value.to_modint
+    end
+  end
+
+  def test_string_to_modint
+    ModInt.mod = 10**9 + 7
+    values = ['-100', '-1', '-2', '0', '1', '2', '10', '123', '100000000000000', '1000000007']
+    values.concat(values.map { |str| "#{str}\n" })
+
+    values.each do |value|
+      expected = ModInt(value.to_i)
+      assert_equal expected, value.to_m
+      assert_equal expected, value.to_modint
+    end
+  end
+
+  def test_output_by_p_method
+    ModInt.mod = 10**9 + 7
+    assert_output("1000000006 mod 1000000007\n") { p(-1.to_m) }
+    assert_output("1000000006 mod 1000000007\n") { p (10**9 + 6).to_m }
+    assert_output("0 mod 1000000007\n") { p (10**9 + 7).to_m }
+    assert_output("1 mod 1000000007\n") { p (10**9 + 8).to_m }
+
+    @mods.each do |mod|
+      ModInt.mod = mod
+
+      @values.each do |n|
+        expected = "#{n % mod} mod #{mod}\n"
+        assert_output(expected) { p n.to_m }
+      end
+    end
+  end
+
+  def test_output_by_puts_method
+    ModInt.mod = 10**9 + 7
+    assert_output("1000000006\n") { puts(-1.to_m) }
+    assert_output("1000000006\n") { puts (10**9 + 6).to_m }
+    assert_output("0\n") { puts (10**9 + 7).to_m }
+    assert_output("1\n") { puts (10**9 + 8).to_m }
+
+    @mods.each do |mod|
+      ModInt.mod = mod
+
+      @values.each do |n|
+        expected = "#{n % mod}\n"
+        assert_output(expected) { puts n.to_m }
+      end
     end
   end
 end

--- a/test/modint_test.rb
+++ b/test/modint_test.rb
@@ -9,9 +9,9 @@ require_relative '../src/modint.rb'
 # test ModInt
 class ModIntTest < Minitest::Test
   def setup
-    @mods = [1, 2, 3, 10, 17, 2**16, 119 * 2**23 + 1, 10**9 + 7]
-    @primes = [2, 3, 5, 7, 11, 13, 17, 10**9 + 7]
-    @values = [-10**5, -23, -2, -1, 0, 1, 2, 5, 10, 100, 1000, 27, 128, 2357, 10**7, 10**100]
+    @mods = [1, 2, 3, 6, 10, 11, 2**16, 119 * 2**23 + 1, 10**9 + 7]
+    @primes = [2, 3, 5, 7, 11, 10**9 + 7]
+    @values = [-10**5, -6, -2, -1, 0, 1, 2, 3, 6, 10**100]
   end
 
   def test_example
@@ -123,10 +123,34 @@ class ModIntTest < Minitest::Test
     end
   end
 
+  def test_equal
+    @mods.each do |mod|
+      ModInt.mod = mod
+
+      @values.each do |value|
+        assert_equal true, (value % mod) == value.to_m
+        assert_equal true, value.to_m == (value % mod)
+        assert_equal true, value.to_m == value.to_m
+      end
+    end
+  end
+
+  def test_not_equal
+    @mods.each do |mod|
+      ModInt.mod = mod
+
+      @values.each do |value|
+        assert_equal false, (value % mod) != value.to_m
+        assert_equal false, value.to_m != (value % mod)
+        assert_equal false, value.to_m != value.to_m
+      end
+    end
+  end
+
   def test_pow
     mods = [1, 2, 3, 10, 17, 2**16, 119 * 2**23 + 1, 10**9 + 7]
-    xs = [-2, -1, 0, 1, 2, 100, 1000]
-    ys = [0, 1, 10, 27, 5, 1000, 128, 2357]
+    xs = [-6, -2, -1, 0, 1, 2, 6, 100]
+    ys = [0, 1, 2, 3, 6, 100]
 
     mods.each do |mod|
       ModInt.mod = mod
@@ -141,8 +165,8 @@ class ModIntTest < Minitest::Test
 
   def test_pow_method
     mods = [2, 3, 10, 17, 2**16, 119 * 2**23 + 1, 10**9 + 7]
-    xs = [-2, -1, 0, 1, 2, 100, 1000]
-    ys = [0, 1, 10, 27, 5, 1000, 128, 2357, 10**9, 10**100]
+    xs = [-6, -2, -1, 0, 1, 2, 6, 100, 10**9 + 7]
+    ys = [0, 1, 2, 3, 6, 10, 10**9, 10**100]
 
     mods.each do |mod|
       ModInt.mod = mod
@@ -153,6 +177,18 @@ class ModIntTest < Minitest::Test
         assert_equal expected, x.to_m.pow(y)
       end
     end
+  end
+
+  def test_pow_in_the_case_mod_is_one
+    # Ruby 2.7.1 may have a bug: i.pow(0, 1) #=> 1 if i is a Integer
+    # this returns should be 0
+    ModInt.mod = 1
+    assert_equal 0, ModInt(-1).pow(0)
+    assert_equal 0, ModInt(0).pow(0)
+    assert_equal 0, ModInt(1).pow(0)
+    assert_equal 0, ModInt(-1)**0
+    assert_equal 0, ModInt(-1)**0
+    assert_equal 0, ModInt(-1)**0
   end
 
   def test_inv_in_the_case_that_mod_is_prime


### PR DESCRIPTION
# ModIntの変更点

以下が主な変更点です。

## インスタンス変数を削除しグローバル変数

- 違うmodどうしの数値の和をとる需要がないため
- コードの可読性向上
- 時間の定数倍改善

上記の理由により、インスタンス変数を削除しました。

なお、クラス変数を利用したコードが遅かったため、暫定的にグローバル変数としました。

## !=(other)メソッドの定義を削除

`Numeric`の継承で、`==`を定義することで`!=`が自動的に作られていたため、削除します。

## **の引数はIntegerのみに

引数が``ModInt`でもto_i`により計算可能でしたが、理論的に`Integer`のみと考え変更しました。

## **のエイリアスでpowメソッドを追加

そのままです。

## テストに`setup`を追加しました。

DRIの意図です。
書くtestメソッドの前に、setupメソッドが実行されます。