### PR TITLE
Improve style(remove frozen string and `then` of if e.t.c.)

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,20 +1,28 @@
 AllCops:
   NewCops: enable
+Layout/SpaceBeforeBlockBraces:
+  Enabled: false
+Layout/SpaceInsideRangeLiteral:
+  Enabled: false
 Naming/MethodParameterName:
   Enabled: false
-Style/NumericPredicate:
-  Enabled: false
 Style/AndOr:
+  Enabled: false
+Style/FrozenStringLiteralComment:
   Enabled: false
 Style/Lambda:
   Enabled: false
 Style/LambdaCall:
+  Enabled: false
+Style/NumericPredicate:
   Enabled: false
 Style/ParallelAssignment:
   Enabled: false
 Style/RedundantFileExtensionInRequire:
   Enabled: false
 Style/StringLiterals:
+  Enabled: false
+Style/TrailingCommaInArrayLiteral:
   Enabled: false
 Metrics/MethodLength:
   Max: 29

--- a/document_ja/two_sat.md
+++ b/document_ja/two_sat.md
@@ -8,7 +8,7 @@
 
 **エイリアス**
 
-`TwoSAT`, `Twosat`, `TwoSat`, `TwoSatisfiability`
+`TwoSAT`, `TwoSat`
 
 <hr>
 

--- a/lib/convolution.rb
+++ b/lib/convolution.rb
@@ -1,11 +1,8 @@
-# frozen_string_literal: true
-
 # usage :
 #
 # conv = Convolution.new(mod, [primitive_root])
 # conv.convolution(a, b) #=> convolution a and b modulo mod.
 #
-
 class Convolution
   def initialize(mod = 998244353, primitive_root = nil)
     @mod = mod
@@ -13,7 +10,7 @@ class Convolution
     cnt2 = bsf(@mod - 1)
     e = (primitive_root||calc_primitive_root(mod)).pow((@mod-1) >> cnt2, @mod)
     ie = e.pow(@mod - 2, @mod)
-    
+
     es = [0]*(cnt2-1)
     ies = [0]*(cnt2-1)
     cnt2.downto(2){ |i|
@@ -41,6 +38,7 @@ class Convolution
 
     h = (n+m-2).bit_length
     raise ArgumentError if h > @sum_e.size
+
     z = 1 << h
 
     a = a+[0]*(z-n)
@@ -106,7 +104,7 @@ class Convolution
     x/=2 while x.even?
     i = 3
     while i*i <= x
-      if x%i == 0 then
+      if x%i == 0
         divs << i
         x/=i while x%i == 0
       end

--- a/lib/crt.rb
+++ b/lib/crt.rb
@@ -1,21 +1,19 @@
-# frozen_string_literal: true
-
 # return [rem, mod] or [0, 0] (if no solution)
 def crt(r, m)
   raise ArgumentError if r.size != m.size
-  
+
   n = r.size
   r0, m0 = 0, 1
   n.times{ |i|
     raise ArgumentError if m[i] < 1
 
     r1, m1 = r[i]%m[i], m[i]
-    if m0 < m1 then
+    if m0 < m1
       r0, r1 = r1, r0
       m0, m1 = m1, m0
     end
 
-    if m0%m1 == 0 then
+    if m0%m1 == 0
       return [0, 0] if r0%m1 != r1
       next
     end

--- a/lib/dsu.rb
+++ b/lib/dsu.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 # Disjoint Set Union
 class DSU
   def initialize(n = 0)

--- a/lib/fenwick_tree.rb
+++ b/lib/fenwick_tree.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 # Fenwick Tree
 class FenwickTree
   attr_reader :data, :size

--- a/lib/floor_sum.rb
+++ b/lib/floor_sum.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 def floor_sum(n, m, a, b)
   res = 0
 

--- a/lib/lazy_segtree.rb
+++ b/lib/lazy_segtree.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 # Segment tree with Lazy propagation
 class LazySegtree
   attr_reader   :d, :lz

--- a/lib/lcp_array.rb
+++ b/lib/lcp_array.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 # lcp array for array of integers or string
 def lcp_array(s, sa)
   s = s.bytes if s === String
@@ -15,6 +13,7 @@ def lcp_array(s, sa)
   n.times{ |i|
     h -= 1 if h > 0
     next if rnk[i] == 0
+
     j = sa[rnk[i]-1]
     h += 1 while j+h<n && i+h<n && s[j+h]==s[i+h]
     lcp[rnk[i]-1] = h

--- a/lib/max_flow.rb
+++ b/lib/max_flow.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 # MaxFlowGraph
 class MaxFlow
   def initialize(n = 0)

--- a/lib/min_cost_flow.rb
+++ b/lib/min_cost_flow.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require_relative '../lib/priority_queue.rb'
 
 # Min Cost Flow Grapsh

--- a/lib/modint.rb
+++ b/lib/modint.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 # ModInt
 class ModInt < Numeric
   class << self

--- a/lib/priority_queue.rb
+++ b/lib/priority_queue.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 # Priority Queue
 # Reference: https://github.com/python/cpython/blob/master/Lib/heapq.py
 class PriorityQueue

--- a/lib/scc.rb
+++ b/lib/scc.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 # Strongly Connected Components
 class SCCGraph
   # initialize graph with n vertices

--- a/lib/segtree.rb
+++ b/lib/segtree.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 # Segment Tree
 class Segtree
   def initialize(arg, e, &block)

--- a/lib/suffix_array.rb
+++ b/lib/suffix_array.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 # induce sort (internal method)
 def sa_is_induce(s, ls, sum_l, sum_s, lms)
   n = s.size
@@ -7,7 +5,7 @@ def sa_is_induce(s, ls, sum_l, sum_s, lms)
 
   buf = sum_s.dup
   lms.each{ |lms|
-    if lms != n then
+    if lms != n
       sa[buf[s[lms]]] = lms
       buf[s[lms]] += 1
     end
@@ -17,7 +15,7 @@ def sa_is_induce(s, ls, sum_l, sum_s, lms)
   sa[buf[s[-1]]] = n-1
   buf[s[-1]] += 1
   sa.each{ |v|
-    if v>=1 && !ls[v-1] then
+    if v>=1 && !ls[v-1]
       sa[buf[s[v-1]]] = v-1
       buf[s[v-1]] += 1
     end
@@ -25,7 +23,7 @@ def sa_is_induce(s, ls, sum_l, sum_s, lms)
 
   buf = sum_l.dup
   sa.reverse_each{ |v|
-    if v>=1 && ls[v-1] then
+    if v>=1 && ls[v-1]
       buf[s[v-1]+1] -= 1
       sa[buf[s[v-1]+1]] = v-1
     end
@@ -49,7 +47,7 @@ def sa_is(s, upper)
   sum_l = [0]*(upper+1)
   sum_s = [0]*(upper+1)
   n.times{ |i|
-    if ls[i] then
+    if ls[i]
       sum_l[s[i]+1] += 1
     else
       sum_s[s[i]] += 1
@@ -78,10 +76,10 @@ def sa_is(s, upper)
     end_l = lms[lms_map[l]+1]||n
     end_r = lms[lms_map[r]+1]||n
     same = true
-    if end_l-l != end_r-r then
+    if end_l-l != end_r-r
       same = false
     else
-      while l < end_l do
+      while l < end_l
         break if s[l] != s[r]
         l+=1
         r+=1
@@ -101,7 +99,7 @@ end
 
 # suffix array for array of integers or string
 def suffix_array(s, upper = nil)
-  if not upper then
+  if not upper
     case s
     when Array
       # compression

--- a/lib/two_sat.rb
+++ b/lib/two_sat.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require_relative './scc.rb'
 
 # TwoSAT
@@ -33,6 +31,4 @@ class TwoSAT
   alias satisfiable? satisfiable
 end
 
-Twosat = TwoSAT
 TwoSat = TwoSAT
-TwoSatisfiability = TwoSAT

--- a/lib/z_algorithm.rb
+++ b/lib/z_algorithm.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 # this implementation is different from ACL because of calculation time
 # ref : https://snuke.hatenablog.com/entry/2014/12/03/214243
 # ACL  implementation : https://atcoder.jp/contests/abc135/submissions/16656972 (1320 ms)
@@ -8,14 +6,14 @@
 def z_algorithm(s)
   n = s.size
   return [] if n == 0
- 
+
   z = [0]*n
   z[0] = n
   i, j = 1, 0
   while i < n
     j += 1 while i+j<n && s[j]==s[i+j]
     z[i] = j
-    if j == 0 then
+    if j == 0
       i += 1
       next
     end
@@ -27,5 +25,6 @@ def z_algorithm(s)
     i += k
     j -= k
   end
+
   return z
 end

--- a/test/crt_test.rb
+++ b/test/crt_test.rb
@@ -10,7 +10,7 @@ class ConvolutionTest < Minitest::Test
     [*1 .. 20].repeated_permutation(2){ |a, b|
       [*-10 .. 10].repeated_permutation(2){ |c, d|
         rem, mod = crt([c, d], [a, b])
-        if mod == 0 then
+        if mod == 0
           assert (0 ... a.lcm(b)).none?{ |x| x%a == c && x%b == d }
         else
           assert_equal a.lcm(b), mod


### PR DESCRIPTION
良くないですが、細かい部分なので色々まとめてのPRです。

以下のIssueに対応しています。
Delete `frozen_string_literal: true` #48 (`lib`ディレクトリに関して、完全対応)
とても消極的にRuboCopを推奨したい #7

他に、ac-libarary-rbのTwoSATに`Twosat`, `TwoSat`, `TwoSatisfiability`とか色々と自分が勝手にエイリアスをつけましたが、コードが出揃った今は「変なエイリアス、使われなさそなエイリアスは不要だな」と感じています。`TwoSatisfiability`は誰が使うのかわらないし、`Twosat`も変に思って使って欲しくないので、`TwoSat`と`TwoSAT`を残して削除しようと思います。