### PR TITLE
Fix style

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,30 +1,115 @@
 AllCops:
   NewCops: enable
+Layout/ExtraSpacing:
+  AutoCorrect: false
+  Exclude:
+    - 'test/convolution_test.rb'
 Layout/SpaceBeforeBlockBraces:
   Enabled: false
+Layout/SpaceInsideArrayLiteralBrackets:
+  AutoCorrect: false
+  Exclude:
+    - 'test/convolution_test.rb'
 Layout/SpaceInsideRangeLiteral:
   Enabled: false
+Lint/BinaryOperatorWithIdenticalOperands:
+  Enabled: false
+Lint/MissingSuper:
+  AutoCorrect: false
+  Exclude:
+    - 'lib/modint.rb'
+Lint/ShadowingOuterLocalVariable:
+  AutoCorrect: false
+  Exclude:
+    - 'lib/convolution.rb'
+    - 'lib/lcp_array.rb'
+    - 'lib/suffix_array.rb'
+    - 'test/convolution_test.rb'
+Metrics/AbcSize:
+  Max: 47
+  Exclude:
+    - 'lib/suffix_array.rb'
+Metrics/ClassLength:
+  Max: 334
+Metrics/CyclomaticComplexity:
+  Max: 13
+  Exclude:
+    - 'lib/suffix_array.rb'
+Metrics/MethodLength:
+  Max: 120
+Metrics/ParameterLists:
+  Exclude:
+    - 'lib/lazy_segtree.rb'
+Metrics/PerceivedComplexity:
+  Max: 13
+  Exclude:
+    - 'lib/suffix_array.rb'
+Naming/AccessorMethodName:
+  Exclude:
+    - 'lib/modint.rb'
+Naming/MethodName:
+  Exclude:
+    - 'lib/modint.rb'
+    - 'test/convolution_test.rb'
 Naming/MethodParameterName:
   Enabled: false
 Style/AndOr:
   Enabled: false
+Style/ArrayCoercion:
+  Enabled: false
+Style/BlockDelimiters:
+  AutoCorrect: false
+  Exclude:
+    - 'lib/convolution.rb'
+    - 'lib/lcp_array.rb'
+    - 'lib/suffix_array.rb'
+    - 'test/convolution_test.rb'
+    - 'test/crt_test.rb'
+Style/GlobalVars:
+  AutoCorrect: false
+  Exclude:
+    - 'lib/modint.rb'
 Style/FrozenStringLiteralComment:
   Enabled: false
 Style/Lambda:
   Enabled: false
 Style/LambdaCall:
   Enabled: false
+Style/MultipleComparison:
+  Enabled: false
 Style/NumericPredicate:
   Enabled: false
+Style/OptionalArguments:
+  AutoCorrect: false
+  Exclude:
+    - 'lib/segtree.rb'
 Style/ParallelAssignment:
   Enabled: false
 Style/RedundantFileExtensionInRequire:
+  Enabled: false
+Style/RedundantReturn:
+  AutoCorrect: false
+  Exclude:
+    - 'lib/convolution.rb'
+    - 'lib/crt.rb'
+    - 'lib/lcp_array.rb'
+    - 'lib/suffix_array.rb'
+    - 'lib/z_algorithm.rb'
+    - 'test/convolution_test.rb'
+Style/SelfAssignment:
+  AutoCorrect: false
+  Exclude:
+    - 'lib/convolution.rb'
+Style/Semicolon:
+  Exclude:
+    - 'lib/lazy_segtree.rb'
+Style/SlicingWithRange:
   Enabled: false
 Style/StringLiterals:
   Enabled: false
 Style/TrailingCommaInArrayLiteral:
   Enabled: false
-Metrics/MethodLength:
-  Max: 29
-Metrics/AbcSize:
-  Max: 43
+Style/WhileUntilModifier:
+  Enabled: false
+Style/YodaCondition:
+  Enabled: false

--- a/lib/convolution.rb
+++ b/lib/convolution.rb
@@ -4,89 +4,89 @@
 # conv.convolution(a, b) #=> convolution a and b modulo mod.
 #
 class Convolution
-  def initialize(mod = 998244353, primitive_root = nil)
+  def initialize(mod = 998_244_353, primitive_root = nil)
     @mod = mod
 
     cnt2 = bsf(@mod - 1)
-    e = (primitive_root||calc_primitive_root(mod)).pow((@mod-1) >> cnt2, @mod)
+    e = (primitive_root || calc_primitive_root(mod)).pow((@mod - 1) >> cnt2, @mod)
     ie = e.pow(@mod - 2, @mod)
 
-    es = [0]*(cnt2-1)
-    ies = [0]*(cnt2-1)
+    es = [0] * (cnt2 - 1)
+    ies = [0] * (cnt2 - 1)
     cnt2.downto(2){ |i|
-      es[i-2] = e
-      ies[i-2] = ie
-      e = e*e % @mod
-      ie = ie*ie % @mod
+      es[i - 2] = e
+      ies[i - 2] = ie
+      e = e * e % @mod
+      ie = ie * ie % @mod
     }
     now = inow = 1
 
-    @sum_e = [0]*cnt2
-    @sum_ie = [0]*cnt2
-    (cnt2-1).times{ |i|
-      @sum_e[i] = es[i]*now % @mod
-      now = now*ies[i] % @mod
-      @sum_ie[i] = ies[i]*inow % @mod
-      inow = inow*es[i] % @mod
+    @sum_e = [0] * cnt2
+    @sum_ie = [0] * cnt2
+    (cnt2 - 1).times{ |i|
+      @sum_e[i] = es[i] * now % @mod
+      now = now * ies[i] % @mod
+      @sum_ie[i] = ies[i] * inow % @mod
+      inow = inow * es[i] % @mod
     }
   end
 
   def convolution(a, b)
     n = a.size
     m = b.size
-    return [] if n==0 || m==0
+    return [] if n == 0 || m == 0
 
-    h = (n+m-2).bit_length
+    h = (n + m - 2).bit_length
     raise ArgumentError if h > @sum_e.size
 
     z = 1 << h
 
-    a = a+[0]*(z-n)
-    b = b+[0]*(z-m)
+    a = a + [0] * (z - n)
+    b = b + [0] * (z - m)
 
     batterfly(a, h)
     batterfly(b, h)
 
-    c = a.zip(b).map{ |a, b| a*b % @mod }
+    c = a.zip(b).map{ |a, b| a * b % @mod }
 
     batterfly_inv(c, h)
 
-    iz = z.pow(@mod-2, @mod)
-    return c[0,n+m-1].map{ |c| c*iz % @mod }
+    iz = z.pow(@mod - 2, @mod)
+    return c[0, n + m - 1].map{ |c| c * iz % @mod }
   end
 
   def batterfly(a, h)
     1.upto(h){ |ph|
-      w = 1 << (ph-1)
-      p = 1 << (h-ph)
+      w = 1 << (ph - 1)
+      p = 1 << (h - ph)
       now = 1
       w.times{ |s|
-        offset = s << (h-ph+1)
-        offset.upto(offset+p-1){ |i|
+        offset = s << (h - ph + 1)
+        offset.upto(offset + p - 1){ |i|
           l = a[i]
-          r = a[i+p]*now % @mod
-          a[i] = l+r
-          a[i+p] = l-r
+          r = a[i + p] * now % @mod
+          a[i] = l + r
+          a[i + p] = l - r
         }
-        now = now*@sum_e[bsf(~s)] % @mod
+        now = now * @sum_e[bsf(~s)] % @mod
       }
     }
   end
 
   def batterfly_inv(a, h)
     h.downto(1){ |ph|
-      w = 1 << (ph-1)
-      p = 1 << (h-ph)
+      w = 1 << (ph - 1)
+      p = 1 << (h - ph)
       inow = 1
       w.times{ |s|
-        offset = s << (h-ph+1)
-        offset.upto(offset+p-1){ |i|
+        offset = s << (h - ph + 1)
+        offset.upto(offset + p - 1){ |i|
           l = a[i]
-          r = a[i+p]
-          a[i] = l+r
-          a[i+p] = (l-r)*inow % @mod
+          r = a[i + p]
+          a[i] = l + r
+          a[i + p] = (l - r) * inow % @mod
         }
-        inow = inow*@sum_ie[bsf(~s)] % @mod
+        inow = inow * @sum_ie[bsf(~s)] % @mod
       }
     }
   end
@@ -97,16 +97,16 @@ class Convolution
 
   def calc_primitive_root(mod)
     return 1 if mod == 2
-    return 3 if mod == 998244353
+    return 3 if mod == 998_244_353
 
     divs = [2]
-    x = (mod-1) / 2
-    x/=2 while x.even?
+    x = (mod - 1) / 2
+    x /= 2 while x.even?
     i = 3
-    while i*i <= x
-      if x%i == 0
+    while i * i <= x
+      if x % i == 0
         divs << i
-        x/=i while x%i == 0
+        x /= i while x % i == 0
       end
       i += 2
     end
@@ -114,7 +114,8 @@ class Convolution
 
     g = 2
     loop{
-      return g if divs.none?{ |d| g.pow((mod-1)/d, mod) == 1 }
+      return g if divs.none?{ |d| g.pow((mod - 1) / d, mod) == 1 }
+
       g += 1
     }
   end

--- a/lib/crt.rb
+++ b/lib/crt.rb
@@ -4,29 +4,30 @@ def crt(r, m)
 
   n = r.size
   r0, m0 = 0, 1
-  n.times{ |i|
+  n.times do |i|
     raise ArgumentError if m[i] < 1
 
-    r1, m1 = r[i]%m[i], m[i]
+    r1, m1 = r[i] % m[i], m[i]
     if m0 < m1
       r0, r1 = r1, r0
       m0, m1 = m1, m0
     end
 
-    if m0%m1 == 0
-      return [0, 0] if r0%m1 != r1
+    if m0 % m1 == 0
+      return [0, 0] if r0 % m1 != r1
+
       next
     end
 
     g, im = inv_gcd(m0, m1)
-    u1 = m1/g
-    return [0, 0] if (r1-r0)%g != 0
+    u1 = m1 / g
+    return [0, 0] if (r1 - r0) % g != 0
 
-    x = (r1-r0)/g*im%u1
-    r0 += x*m0
+    x = (r1 - r0) / g * im % u1
+    r0 += x * m0
     m0 *= u1
     r0 += m0 if r0 < 0
-  }
+  end
 
   return [r0, m0]
 end
@@ -41,11 +42,11 @@ def inv_gcd(a, b)
   m0, m1 = 0, 1
   while t > 0
     u, s = s.divmod(t)
-    m0 -= m1*u
+    m0 -= m1 * u
     s, t = t, s
     m0, m1 = m1, m0
   end
-  m0 += b/s if m0 < 0
+  m0 += b / s if m0 < 0
 
   return [s, m0]
 end

--- a/lib/lcp_array.rb
+++ b/lib/lcp_array.rb
@@ -1,22 +1,22 @@
 # lcp array for array of integers or string
 def lcp_array(s, sa)
-  s = s.bytes if s === String
+  s = s.bytes if s.is_a?(String)
 
   n = s.size
-  rnk = [0]*n
+  rnk = [0] * n
   sa.each_with_index{ |sa, id|
     rnk[sa] = id
   }
 
-  lcp = [0]*(n-1)
+  lcp = [0] * (n - 1)
   h = 0
   n.times{ |i|
     h -= 1 if h > 0
     next if rnk[i] == 0
 
-    j = sa[rnk[i]-1]
-    h += 1 while j+h<n && i+h<n && s[j+h]==s[i+h]
-    lcp[rnk[i]-1] = h
+    j = sa[rnk[i] - 1]
+    h += 1 while j + h < n && i + h < n && s[j + h] == s[i + h]
+    lcp[rnk[i] - 1] = h
   }
 
   return lcp

--- a/lib/modint.rb
+++ b/lib/modint.rb
@@ -43,11 +43,11 @@ class ModInt < Numeric
 
     def inv_gcd(a, b)
       a %= b
-      return [b, 0] if 0 == a
+      return [b, 0] if a == 0
 
       s, t = b, a
       m0, m1 = 0, 1
-      while 0 != t
+      while t != 0
         u = s / t
         s -= t * u
         m0 -= m1 * u

--- a/lib/suffix_array.rb
+++ b/lib/suffix_array.rb
@@ -1,7 +1,7 @@
 # induce sort (internal method)
 def sa_is_induce(s, ls, sum_l, sum_s, lms)
   n = s.size
-  sa = [-1]*n
+  sa = [-1] * n
 
   buf = sum_s.dup
   lms.each{ |lms|
@@ -12,20 +12,20 @@ def sa_is_induce(s, ls, sum_l, sum_s, lms)
   }
 
   buf = sum_l.dup
-  sa[buf[s[-1]]] = n-1
+  sa[buf[s[-1]]] = n - 1
   buf[s[-1]] += 1
   sa.each{ |v|
-    if v>=1 && !ls[v-1]
-      sa[buf[s[v-1]]] = v-1
-      buf[s[v-1]] += 1
+    if v >= 1 && !ls[v - 1]
+      sa[buf[s[v - 1]]] = v - 1
+      buf[s[v - 1]] += 1
     end
   }
 
   buf = sum_l.dup
   sa.reverse_each{ |v|
-    if v>=1 && ls[v-1]
-      buf[s[v-1]+1] -= 1
-      sa[buf[s[v-1]+1]] = v-1
+    if v >= 1 && ls[v - 1]
+      buf[s[v - 1] + 1] -= 1
+      sa[buf[s[v - 1] + 1]] = v - 1
     end
   }
 
@@ -39,28 +39,28 @@ def sa_is(s, upper)
   return [] if n == 0
   return [0] if n == 1
 
-  ls = [false]*n
-  (n-2).downto(0){ |i|
-    ls[i] = (s[i] == s[i+1] ? ls[i+1] : s[i] < s[i+1])
+  ls = [false] * n
+  (n - 2).downto(0){ |i|
+    ls[i] = (s[i] == s[i + 1] ? ls[i + 1] : s[i] < s[i + 1])
   }
 
-  sum_l = [0]*(upper+1)
-  sum_s = [0]*(upper+1)
+  sum_l = [0] * (upper + 1)
+  sum_s = [0] * (upper + 1)
   n.times{ |i|
     if ls[i]
-      sum_l[s[i]+1] += 1
+      sum_l[s[i] + 1] += 1
     else
       sum_s[s[i]] += 1
     end
   }
   0.upto(upper){ |i|
     sum_s[i] += sum_l[i]
-    sum_l[i+1] += sum_s[i] if i < upper
+    sum_l[i + 1] += sum_s[i] if i < upper
   }
 
-  lms = (1 ... n).select{ |i| !ls[i-1] && ls[i] }
+  lms = (1 ... n).select{ |i| !ls[i - 1] && ls[i] }
   m = lms.size
-  lms_map = [-1]*(n+1)
+  lms_map = [-1] * (n + 1)
   lms.each_with_index{ |lms, id| lms_map[lms] = id }
 
   sa = sa_is_induce(s, ls, sum_l, sum_s, lms)
@@ -68,27 +68,28 @@ def sa_is(s, upper)
   return sa if m == 0
 
   sorted_lms = sa.select{ |sa| lms_map[sa] != -1 }
-  rec_s = [0]*m
+  rec_s = [0] * m
   rec_upper = 0
   rec_s[lms_map[sorted_lms[0]]] = 0
-  1.upto(m-1){ |i|
-    l, r = sorted_lms[i-1, 2]
-    end_l = lms[lms_map[l]+1]||n
-    end_r = lms[lms_map[r]+1]||n
+  1.upto(m - 1) do |i|
+    l, r = sorted_lms[i - 1, 2]
+    end_l = lms[lms_map[l] + 1] || n
+    end_r = lms[lms_map[r] + 1] || n
     same = true
-    if end_l-l != end_r-r
+    if end_l - l != end_r - r
       same = false
     else
       while l < end_l
         break if s[l] != s[r]
-        l+=1
-        r+=1
+
+        l += 1
+        r += 1
       end
-      same = false if l==n || s[l]!=s[r]
+      same = false if l == n || s[l] != s[r]
     end
     rec_upper += 1 if not same
     rec_s[lms_map[sorted_lms[i]]] = rec_upper
-  }
+  end
 
   sa_is(rec_s, rec_upper).each_with_index{ |rec_sa, id|
     sorted_lms[id] = lms[rec_sa]
@@ -105,11 +106,11 @@ def suffix_array(s, upper = nil)
       # compression
       n = s.size
       idx = (0 ... n).sort_by{ |i| s[i] }
-      t = [0]*n
+      t = [0] * n
       upper = 0
       t[idx[0]] = 0
-      1.upto(n-1){ |i|
-        upper += 1 if s[idx[i-1]] != s[idx[i]]
+      1.upto(n - 1){ |i|
+        upper += 1 if s[idx[i - 1]] != s[idx[i]]
         t[idx[i]] = upper
       }
       s = t
@@ -119,7 +120,7 @@ def suffix_array(s, upper = nil)
     end
   else
     s.each{ |s|
-      raise ArgumentError if s<0 || upper<s
+      raise ArgumentError if s < 0 || upper < s
     }
   end
 

--- a/lib/z_algorithm.rb
+++ b/lib/z_algorithm.rb
@@ -7,19 +7,19 @@ def z_algorithm(s)
   n = s.size
   return [] if n == 0
 
-  z = [0]*n
+  z = [0] * n
   z[0] = n
   i, j = 1, 0
   while i < n
-    j += 1 while i+j<n && s[j]==s[i+j]
+    j += 1 while i + j < n && s[j] == s[i + j]
     z[i] = j
     if j == 0
       i += 1
       next
     end
     k = 1
-    while i+k<n && k+z[k]<j
-      z[i+k] = z[k]
+    while i + k < n && k + z[k] < j
+      z[i + k] = z[k]
       k += 1
     end
     i += k

--- a/test/convolution_test.rb
+++ b/test/convolution_test.rb
@@ -8,10 +8,10 @@ require_relative '../lib/convolution.rb'
 def convolution_naive(a, b, mod)
   n = a.size
   m = b.size
-  c = [0]*(n+m-1)
+  c = [0] * (n + m - 1)
   n.times{ |i|
     m.times{ |j|
-      c[i+j] += a[i]*b[j]
+      c[i + j] += a[i] * b[j]
     }
   }
   return c.map{ |c| c % mod }
@@ -32,19 +32,19 @@ class ConvolutionTest < Minitest::Test
     20.times{
       a = (0 .. rand(100)).map{ rand(-max_num .. max_num) }
       b = (0 .. rand(100)).map{ rand(-max_num .. max_num) }
-      assert_equal convolution_naive(a, b, 998244353), conv.convolution(a, b)
+      assert_equal convolution_naive(a, b, 998_244_353), conv.convolution(a, b)
     }
   end
 
   def test_random_array_modulo_NTT_friendly_given_proot
     max_num = 10**18
-    [[ 998244353,          5], # [mod, primitive_root]
-     [ 998244353,  100000005],
-     [ 998244353,  998244350],
-     [1012924417,          5],
-     [1012924417, 1012924412],
-     [ 924844033,          5],
-     [ 924844033,  924844028]].each{ |mod, proot|
+    [[  998_244_353,             5], # [mod, primitive_root]
+     [  998_244_353,   100_000_005],
+     [  998_244_353,   998_244_350],
+     [1_012_924_417,             5],
+     [1_012_924_417, 1_012_924_412],
+     [  924_844_033,             5],
+     [  924_844_033,   924_844_028]].each{ |mod, proot|
       conv = Convolution.new(mod, proot)
       20.times{
         a = (0 ... 100).map{ rand(-max_num .. max_num) }
@@ -56,7 +56,7 @@ class ConvolutionTest < Minitest::Test
 
   def test_random_array_modulo_NTT_friendly_not_given_proot
     max_num = 10**18
-    [998244353, 1012924417, 924844033].each{ |mod|
+    [998_244_353, 1_012_924_417, 924_844_033].each{ |mod|
       conv = Convolution.new(mod)
       20.times{
         a = (0 ... 100).map{ rand(-max_num .. max_num) }
@@ -71,7 +71,7 @@ class ConvolutionTest < Minitest::Test
     [641, 769].each{ |mod|
       conv = Convolution.new(mod)
       limlen = 1
-      limlen *= 2 while (mod-1)%limlen == 0
+      limlen *= 2 while (mod - 1) % limlen == 0
       limlen /= 2
       20.times{
         len_a = rand(limlen) + 1
@@ -87,12 +87,12 @@ class ConvolutionTest < Minitest::Test
     [641, 769].each{ |mod|
       conv = Convolution.new(mod)
       limlen = 1
-      limlen *= 2 while (mod-1)%limlen == 0
+      limlen *= 2 while (mod - 1) % limlen == 0
       limlen /= 2
       # a.size + b.size - 1 == limlen + 1 > limlen
       assert_raises(ArgumentError){ conv.convolution([*0 ... limlen], [0, 0]) }
       assert_raises(ArgumentError){ conv.convolution([0, 0], [*0 ... limlen]) }
-      assert_raises(ArgumentError){ conv.convolution([*0 .. limlen/2], [*0 .. limlen/2]) }
+      assert_raises(ArgumentError){ conv.convolution([*0 .. limlen / 2], [*0 .. limlen / 2]) }
     }
   end
 
@@ -115,8 +115,8 @@ class ConvolutionTest < Minitest::Test
       # ref : https://qiita.com/koshilife/items/ba3a9f7a3ebe85503e4a
       g = conv.send(:calc_primitive_root, prime)
       r = 1
-      assert (1 .. prime-2).all?{
-        r = r*g % prime
+      assert (1 .. prime - 2).all?{
+        r = r * g % prime
         r != 1
       }
     }

--- a/test/crt_test.rb
+++ b/test/crt_test.rb
@@ -11,11 +11,11 @@ class ConvolutionTest < Minitest::Test
       [*-10 .. 10].repeated_permutation(2){ |c, d|
         rem, mod = crt([c, d], [a, b])
         if mod == 0
-          assert (0 ... a.lcm(b)).none?{ |x| x%a == c && x%b == d }
+          assert (0 ... a.lcm(b)).none?{ |x| x % a == c && x % b == d }
         else
           assert_equal a.lcm(b), mod
-          assert_equal c%a, rem%a
-          assert_equal d%b, rem%b
+          assert_equal c % a, rem % a
+          assert_equal d % b, rem % b
         end
       }
     }
@@ -27,12 +27,12 @@ class ConvolutionTest < Minitest::Test
         rem, mod = crt([d, e, f], [a, b, c])
         lcm = [a, b, c].reduce :lcm
         if mod == 0
-          assert (0 ... lcm).none?{ |x| x%a == d && x%b == e && x%c == f }
+          assert (0 ... lcm).none?{ |x| x % a == d && x % b == e && x % c == f }
         else
           assert_equal lcm, mod
-          assert_equal d%a, rem%a
-          assert_equal e%b, rem%b
-          assert_equal f%c, rem%c
+          assert_equal d % a, rem % a
+          assert_equal e % b, rem % b
+          assert_equal f % c, rem % c
         end
       }
     }
@@ -63,11 +63,11 @@ class ConvolutionTest < Minitest::Test
     # different size
     assert_raises(ArgumentError){ crt([], [1]) }
     assert_raises(ArgumentError){ crt([1], []) }
-    assert_raises(ArgumentError){ crt([*1 .. 10**5], [*1 .. 10**5-1]) }
-    assert_raises(ArgumentError){ crt([*1 .. 10**5-1], [*1 .. 10**5]) }
+    assert_raises(ArgumentError){ crt([*1 .. 10**5], [*1 .. 10**5 - 1]) }
+    assert_raises(ArgumentError){ crt([*1 .. 10**5 - 1], [*1 .. 10**5]) }
 
     # modulo 0
     assert_raises(ArgumentError){ crt([0], [0]) }
-    assert_raises(ArgumentError){ crt([0]*5, [2, 3, 5, 7, 0]) }
+    assert_raises(ArgumentError){ crt([0] * 5, [2, 3, 5, 7, 0]) }
   end
 end

--- a/test/example/convolution_practice.rb
+++ b/test/example/convolution_practice.rb
@@ -8,4 +8,4 @@ require_relative '../../lib/convolution.rb'
 _, a, b = $<.map{ |e| e.split.map &:to_i }
 
 conv = Convolution.new
-puts conv.convolution(a, b).join(?\s)
+puts conv.convolution(a, b).join("\s")

--- a/test/example/crt.rb
+++ b/test/example/crt.rb
@@ -14,5 +14,5 @@ if r == 0 && m == 0
   puts -1
 else
   r = m if r == 0
-  puts r % (10**9+7)
+  puts r % (10**9 + 7)
 end

--- a/test/lcp_array_test.rb
+++ b/test/lcp_array_test.rb
@@ -7,11 +7,11 @@ require_relative '../lib/suffix_array.rb'
 require_relative '../lib/lcp_array.rb'
 
 def lcp_array_naive(s)
-  s = s.bytes if s === String
+  s = s.bytes if s.is_a?(String)
   n = s.size
   return (0 ... n).map{ |i| s[i..-1] }.sort.each_cons(2).map{ |s, t|
     lcp = 0
-    lcp += 1 while lcp<s.size && lcp<t.size && s[lcp]==t[lcp]
+    lcp += 1 while lcp < s.size && lcp < t.size && s[lcp] == t[lcp]
     lcp
   }
 end

--- a/test/modint_test.rb
+++ b/test/modint_test.rb
@@ -84,6 +84,21 @@ class ModIntTest < Minitest::Test
     assert_equal 7, -ModInt.new(4)
   end
 
+  def test_self_prime?
+    assert_equal false, ModInt.prime?(1)
+    assert_equal true,  ModInt.prime?(2)
+    assert_equal true,  ModInt.prime?(3)
+    assert_equal false, ModInt.prime?(4)
+    assert_equal true,  ModInt.prime?(5)
+    assert_equal false, ModInt.prime?(6)
+    assert_equal true,  ModInt.prime?(7)
+    assert_equal false, ModInt.prime?(8)
+    assert_equal false, ModInt.prime?(9)
+    assert_equal false, ModInt.prime?(10)
+    assert_equal true,  ModInt.prime?(11)
+    assert_equal true,  ModInt.prime?(10**9 + 7)
+  end
+
   def test_add
     @mods.each do |mod|
       ModInt.mod = mod

--- a/test/suffix_array_test.rb
+++ b/test/suffix_array_test.rb
@@ -56,10 +56,10 @@ class SuffixArrayTest < Minitest::Test
   end
 
   def test_mississippi
-    assert_equal [10,7,4,1,0,9,8,6,3,5,2], suffix_array("mississippi")
+    assert_equal [10, 7, 4, 1, 0, 9, 8, 6, 3, 5, 2], suffix_array("mississippi")
   end
 
   def test_abracadabra
-    assert_equal [10,7,0,3,5,8,1,4,6,9,2], suffix_array("abracadabra")
+    assert_equal [10, 7, 0, 3, 5, 8, 1, 4, 6, 9, 2], suffix_array("abracadabra")
   end
 end

--- a/test/z_algorithm_test.rb
+++ b/test/z_algorithm_test.rb
@@ -9,7 +9,7 @@ def z_algorithm_naive(s)
   n = s.size
   return (0 ... n).map{ |i|
     j = 0
-    j += 1 while i+j<n && s[j]==s[i+j]
+    j += 1 while i + j < n && s[j] == s[i + j]
     j
   }
 end
@@ -46,7 +46,7 @@ class ZAlgorithmTest < Minitest::Test
   end
 
   def test_random_array_of_array
-    candidate = [[],[0],[1],[2],[0, 0],[1, 1],[2, 2]]
+    candidate = [[], [0], [1], [2], [0, 0], [1, 1], [2, 2]]
     20.times{
       a = (0 ... 100).map{ candidate.sample.dup }
       assert_equal z_algorithm_naive(a), z_algorithm(a)
@@ -57,7 +57,7 @@ class ZAlgorithmTest < Minitest::Test
     max_n = 10**5
     20.times{
       n = rand(1..max_n)
-      s = 'A'*n
+      s = 'A' * n
       assert_equal [*1 .. n].reverse, z_algorithm(s)
     }
   end
@@ -68,7 +68,7 @@ class ZAlgorithmTest < Minitest::Test
       a = (0 ... 10**5).map{ rand(-max_num .. max_num) }.uniq
       n = a.size
       # [n, 0, 0, ..., 0]
-      assert_equal [n]+[0]*(n-1), z_algorithm(a)
+      assert_equal [n] + [0] * (n - 1), z_algorithm(a)
     }
   end
 end


### PR DESCRIPTION
演算子の周りは基本的に半角スペースを挿入しました。
ない方が見やすいケースもあるかもしれませんが、一律にした方が楽だろうと思ったためです。

`x * x`はRuboCopデフォルトで警告がでますが、`x**2`と比べて少し速かったので、警告を緩めてしまいました。

`998244353` -> `998_244_353`
10,000以上は、アンダースコアを入れた方が見やすいと思いました。