### PR TITLE
Fix markdown about link

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -21,8 +21,7 @@ ACLの詳細は、以下をご覧ください.
 
 目次(および進捗情報)は、[index.md](https://github.com/universato/ac-library-rb/blob/master/document_ja/index.md)をご覧ください。
 
-また、コピペ以外の方法として、バンドルツール[expander-rb]
-(https://github.com/surpace/expander-rb)(by surpaceさん)を利用する方法もあります。
+また、コピペ以外の方法として、バンドルツール[expander-rb](https://github.com/surpace/expander-rb)(by surpaceさん)を利用する方法もあります。
 
 ## Rubyバージョン
 


### PR DESCRIPTION
凡ミスでリンクが機能してなかったので、修正。
具体的にいうと、マークダウンのリンクの記法で、タイトルとURLの間に余計な改行(それともスペース?)が入っていてリンクが機能してなかったので、その改行を削除して修正しました。