### PR TITLE
Add methods(pow_mod & inv_mod) and fix links

### DIFF
--- a/document_ja/index.md
+++ b/document_ja/index.md
@@ -17,6 +17,8 @@
 | [◎](https://github.com/universato/ac-library-rb/blob/master/lib/suffix_array.rb) | [◎G](https://github.com/universato/ac-library-rb/blob/master/document_ja/string.md)  |suffix_array|
 | [◎](https://github.com/universato/ac-library-rb/blob/master/lib/lcp_array.rb) | [◎G](https://github.com/universato/ac-library-rb/blob/master/document_ja/string.md)  |lcp_array|
 | [◎](https://github.com/universato/ac-library-rb/blob/master/lib/z_algorithm.rb) | [◎G](https://github.com/universato/ac-library-rb/blob/master/document_ja/string.md)  |z_algorithm|
+| [◎](https://github.com/universato/ac-library-rb/blob/master/lib/pow_mod.rb) | [◎G](https://github.com/universato/ac-library-rb/blob/master/document_ja/math.md)  |pow_mod|
+| [◎](https://github.com/universato/ac-library-rb/blob/master/lib/inv_mod.rb) | [◎G](https://github.com/universato/ac-library-rb/blob/master/document_ja/math.md)  |inv_mod|
 | [◎](https://github.com/universato/ac-library-rb/blob/master/lib/crt.rb) | [◎G](https://github.com/universato/ac-library-rb/blob/master/document_ja/math.md)  |crt(中国剰余定理)|
 | [◎](https://github.com/universato/ac-library-rb/blob/master/lib/floor_sum.rb) | [◎G](https://github.com/universato/ac-library-rb/blob/master/document_ja/math.md) |floor_sum|
 | [◎](https://github.com/universato/ac-library-rb/blob/master/lib/convolution.rb) | [◎G](https://github.com/universato/ac-library-rb/blob/master/document_ja/convolution.md) |convolution|
@@ -45,6 +47,8 @@
 ### 数学
 
 - math
+  - [pow_mod.rb](https://github.com/universato/ac-library-rb/blob/master/lib/pow_mod.rb)
+  - [inv_mod.rb](https://github.com/universato/ac-library-rb/blob/master/lib/inv_mod.rb)
   - [crt.rb](https://github.com/universato/ac-library-rb/blob/master/lib/crt.rb)
   - [floor_sum.rb](https://github.com/universato/ac-library-rb/blob/master/lib/floor_sum.rb)
 - [convolution.rb](https://github.com/universato/ac-library-rb/blob/master/lib/convolution.rb)
@@ -68,11 +72,13 @@
 [dsu.rb](https://github.com/universato/ac-library-rb/blob/master/lib/dsu.rb)
 [fenwick_tree.rb](https://github.com/universato/ac-library-rb/blob/master/lib/fenwick_tree.rb)
 [floor_sum.rb](https://github.com/universato/ac-library-rb/blob/master/lib/floor_sum..rb)
+[inv_mod.rb](https://github.com/universato/ac-library-rb/blob/master/lib/inv_mod.rb)
 [lazy_segtree.rb](https://github.com/universato/ac-library-rb/blob/master/lib/lazy_segtree.rb)
 [lcp_array.rb](https://github.com/universato/ac-library-rb/blob/master/lib/lcp_array.rb)
 [max_flow.rb](https://github.com/universato/ac-library-rb/blob/master/lib/max_flow.rb)
 [min_cost_flow.rb](https://github.com/universato/ac-library-rb/blob/master/lib/min_cost_flow.rb)
 [modint.rb](https://github.com/universato/ac-library-rb/blob/master/lib/modint.rb)
+[pow_mod.rb](https://github.com/universato/ac-library-rb/blob/master/lib/pow_mod.rb)
 [priority_queue.rb](https://github.com/universato/ac-library-rb/blob/master/lib/priority_queue.rb)
 [scc.rb](https://github.com/universato/ac-library-rb/blob/master/lib/scc.rb)
 [segtree.rb](https://github.com/universato/ac-library-rb/blob/master/lib/segtree.rb)

--- a/document_ja/lazy_segtree.md
+++ b/document_ja/lazy_segtree.md
@@ -102,12 +102,12 @@ seg.range_apply(l, r, val)
 ## Verified
 
 問題のリンクです。コードはないですが、Verified済みです。
-[AIZU ONLINE JUDGE DSL\_2\_F RMQ and RUQ](http://judge.u-aizu.ac.jp/onlinejudge/description.jsp?id=DSL_2_F)
-[AIZU ONLINE JUDGE DSL\_2\_G RSQ and RAQ](http://judge.u-aizu.ac.jp/onlinejudge/description.jsp?id=DSL_2_G)
+- [AIZU ONLINE JUDGE DSL\_2\_F RMQ and RUQ](http://judge.u-aizu.ac.jp/onlinejudge/description.jsp?id=DSL_2_F)
+- [AIZU ONLINE JUDGE DSL\_2\_G RSQ and RAQ](http://judge.u-aizu.ac.jp/onlinejudge/description.jsp?id=DSL_2_G)
 
 以下の問題は、Rubyでは実行時間が厳しくTLEになりACできてないです。
-[ALPC: K \- Range Affine Range Sum](https://atcoder.jp/contests/practice2/tasks/practice2_k)
-[ALPC: L \- Lazy Segment Tree](https://atcoder.jp/contests/practice2/tasks/practice2_l)
+- [ALPC: K \- Range Affine Range Sum](https://atcoder.jp/contests/practice2/tasks/practice2_k)
+- [ALPC: L \- Lazy Segment Tree](https://atcoder.jp/contests/practice2/tasks/practice2_l)
 
 ## 参考リンク
 
@@ -118,7 +118,7 @@ seg.range_apply(l, r, val)
   - [本家ライブラリのドキュメント lazysegtree.md(GitHub)](https://github.com/atcoder/ac-library/blob/master/document_ja/lazysegtree.md)
   - [本家のドキュメント appendix.md(GitHub)](https://github.com/atcoder/ac-library/blob/master/document_ja/appendix.md)
   - [本家ライブラリの実装コード lazysegtree.hpp(GitHub)](https://github.com/atcoder/ac-library/blob/master/atcoder/lazysegtree.hpp)
-  - [本家ライブラリのテストコード lazysegtree_test.hpp(GitHub)](https://github.com/atcoder/ac-library/blob/master/test/unittest/lazysegtree_test.cpp)
+  - [本家ライブラリのテストコード lazysegtree_test.cpp(GitHub)](https://github.com/atcoder/ac-library/blob/master/test/unittest/lazysegtree_test.cpp)
 - セグメントツリーについて
   - [セグメント木をソラで書きたいあなたに \- hogecoder](https://tsutaj.hatenablog.com/entry/2017/03/29/204841)
   - [遅延評価セグメント木をソラで書きたいあなたに \- hogecoder](https://tsutaj.hatenablog.com/entry/2017/03/30/224339)

--- a/document_ja/math.md
+++ b/document_ja/math.md
@@ -1,5 +1,41 @@
 # Math
 
+数学的アルゴリズムの詰め合わせです。
+
+`pow_mod`, `inv_mod`, `crt`, `floor_sum`について記述します。
+
+## pow_mod
+
+```ruby
+pow_mod(x, n, m)
+```
+
+`(x**n) % m`を返します。
+
+Rubyには、もともと`Integer#pow`があるため、そちらを利用した方がいいです。
+
+基本的に、`pow_mod(x, n, m)`は、`x.pow(n, m)`と等しいです。
+
+ただ、Ruby 2.7.1の時点で、`Integer#pow`は、`x.pow(0, 1)`で「mod 1」なのに`1`を返す小さなバグがあります。
+
+**制約** 引数は、整数で、次の条件を満たします。`0 ≦ n`, `1 ≦ m`
+
+**計算量** `O(log n)`
+
+## inv_mod
+
+```ruby
+inv_mod(x, n, m)
+```
+
+`xy ≡ 1 (mod m)`なる`y`のうち、`0 ≦ y < m`を満たすものを返します。
+
+mが素数のときは、フェルマーの小定理より`x.pow(m - 2, m)`と書けるので、そちらを利用して下さい。
+
+**制約** `gcd(x, m) = 1`, `1 ≦ m`
+
+**計算量** `O(log m)`
+
 ## crt(r, m) -> [rem , mod] or [0, 0]
 
 中国剰余定理
@@ -20,13 +56,6 @@ Chinese remainder theorem
 問題
 [No\.187 中華風 \(Hard\) \- yukicoder](https://yukicoder.me/problems/no/187)
 
-## 参考リンク
-
-- [当ライブラリの実装コード crt.rb](https://github.com/universato/ac-library-rb/blob/master/lib/crt.rb)
-- 本家
-  - [本家ライブラリの実装コード math.hpp](https://github.com/atcoder/ac-library/blob/master/atcoder/math.hpp)
-  - [本家ライブラリのドキュメント math.md](https://github.com/atcoder/ac-library/blob/master/document_ja/math.md)
-
 ## floor_sum(n, m, a, b)
 
 $\sum_{i = 0}^{n - 1} \mathrm{floor}(\frac{a \times i + b}{m})$
@@ -44,9 +73,21 @@ $\sum_{i = 0}^{n - 1} \mathrm{floor}(\frac{a \times i + b}{m})$
 
 ## 参考リンク
 
-- [当ライブラリの実装コード floor_sum.rb](https://github.com/universato/ac-library-rb/blob/master/lib/floor_sum.rb)
-- 本家
+- 当ライブラリ
+  - 当ライブラリの実装コード 
+    - [当ライブラリの実装コード pow_mod.rb](https://github.com/universato/ac-library-rb/blob/master/lib/pow_mod.rb)
+    - [当ライブラリの実装コード inv_mod.rb](https://github.com/universato/ac-library-rb/blob/master/lib/inv_mod.rb)
+    - [当ライブラリの実装コード crt.rb](https://github.com/universato/ac-library-rb/blob/master/lib/crt.rb)
+    - [当ライブラリの実装コード floor_sum.rb](https://github.com/universato/ac-library-rb/blob/master/lib/floor_sum.rb)
+  - テストコード 
+    - [当ライブラリのテストコード pow_mod_test.rb](https://github.com/universato/ac-library-rb/blob/master/test/pow_mod.rb)
+    - [当ライブラリのテストコード inv_mod_test.rb](https://github.com/universato/ac-library-rb/blob/master/test/inv_mod.rb)
+    - [当ライブラリのテストコード crt_test.rb](https://github.com/universato/ac-library-rb/blob/master/test/crt.rb)
+    - [当ライブラリのテストコード floor_sum_test.rb](https://github.com/universato/ac-library-rb/test/master/lib/floor_sum.rb)
+- 本家ライブラリ
   - [本家ライブラリの実装コード math.hpp](https://github.com/atcoder/ac-library/blob/master/atcoder/math.hpp)
+  - [本家ライブラリの実装コード internal_math.hpp](https://github.com/atcoder/ac-library/blob/master/atcoder/internal_math.hpp)
+  - [本家ライブラリのテストコード math_test.cpp](https://github.com/atcoder/ac-library/blob/master/test/unittest/math_test.cpp)
   - [本家ライブラリのドキュメント math.md](https://github.com/atcoder/ac-library/blob/master/document_ja/math.md)
   - [Relax the constraints of floor\_sum? · Issue \#33 · atcoder/ac\-library](https://github.com/atcoder/ac-library/issues/33)
 

--- a/document_ja/max_flow.md
+++ b/document_ja/max_flow.md
@@ -99,7 +99,7 @@ graph.edges
 - 本家ライブラリ
   - 本家のコード 
     - [本家の実装コード maxflow.hpp(GitHub)](https://github.com/atcoder/ac-library/blob/master/atcoder/maxflow.hpp)
-    - [本家のテストコード maxflow_test.hpp(GitHub)](https://github.com/atcoder/ac-library/blob/master/test/unittest/maxflow_test.cpp)
+    - [本家のテストコード maxflow_test.cpp(GitHub)](https://github.com/atcoder/ac-library/blob/master/test/unittest/maxflow_test.cpp)
   - 本家ドキュメント
     - [本家のドキュメント maxflow.md(GitHub)](https://github.com/atcoder/ac-library/blob/master/document_ja/maxflow.md)
     - [本家のドキュメント appendix.md(GitHub)](https://github.com/atcoder/ac-library/blob/master/document_ja/appendix.md)

--- a/document_ja/min_cost_flow.md
+++ b/document_ja/min_cost_flow.md
@@ -84,7 +84,7 @@ graph.edges
 - 本家ライブラリ 
   - [本家ライブラリのドキュメント mincostflow.md(GitHub)](https://github.com/atcoder/ac-library/blob/master/document_ja/mincostflow.md)
   - [本家ライブラリの実装コード mincostflow.hpp(GitHub)](https://github.com/atcoder/ac-library/blob/master/atcoder/mincostflow.hpp)
-  - [本家ライブラリのテストコード mincostflow_test.hpp(GitHub)](https://github.com/atcoder/ac-library/blob/master/test/unittest/mincostflow_test.cpp)
+  - [本家ライブラリのテストコード mincostflow_test.cpp(GitHub)](https://github.com/atcoder/ac-library/blob/master/test/unittest/mincostflow_test.cpp)
 
 ## Q&A
 

--- a/document_ja/modint.md
+++ b/document_ja/modint.md
@@ -216,7 +216,7 @@ p 12.to_m == 1 #=> true
   - [当ライブラリのコード modint_test.rb(GitHub)](https://github.com/universato/ac-library-rb/blob/master/lib/modint.rb)
 - 本家ライブラリ
   - [本家の実装コード modint.hpp(GitHub)](https://github.com/atcoder/ac-library/blob/master/atcoder/modint.hpp)
-  - [本家のテストコード modint_test.hpp(GitHub)](https://github.com/atcoder/ac-library/blob/master/atcoder/modint.hpp)
+  - [本家のテストコード modint_test.cpp(GitHub)](https://github.com/atcoder/ac-library/blob/master/atcoder/modint.hpp)
   - [本家のドキュメント modint.md(GitHub)](https://github.com/atcoder/ac-library/blob/master/document_ja/modint.md)
 - Rubyリファレンスマニュアル
   - [class Numeric \(Ruby 2\.7\.0 リファレンスマニュアル\)](https://docs.ruby-lang.org/ja/latest/class/Numeric.html)

--- a/document_ja/segtree.md
+++ b/document_ja/segtree.md
@@ -110,8 +110,8 @@ Segtree上で二分探索をします。
   - [本家ライブラリのドキュメント segtree.md(GitHub)](https://github.com/atcoder/ac-library/blob/master/document_ja/segtree.md)
   - [本家のドキュメント appendix.md(GitHub)](https://github.com/atcoder/ac-library/blob/master/document_ja/appendix.md)
   - [本家ライブラリの実装コード segtree.hpp(GitHub)](https://github.com/atcoder/ac-library/blob/master/atcoder/segtree.hpp)
-  - [本家ライブラリのテストコード segtree_test.hpp(GitHub)](https://github.com/atcoder/ac-library/blob/master/test/unittest/segtree_test.cpp)
-  - [本家ライブラリのサンプルコード segtree_test.hpp(GitHub)](https://github.com/atcoder/ac-library/tree/master/test/example)
+  - [本家ライブラリのテストコード segtree_test.cpp(GitHub)](https://github.com/atcoder/ac-library/blob/master/test/unittest/segtree_test.cpp)
+  - [本家ライブラリのサンプルコード segtree_practice.cpp(GitHub)](https://github.com/atcoder/ac-library/blob/master/test/example/segtree_practice.cpp)
 - セグメントツリーについて
   - [セグメント木をソラで書きたいあなたに \- hogecoder](https://tsutaj.hatenablog.com/entry/2017/03/29/204841)
 

--- a/lib/inv_mod.rb
+++ b/lib/inv_mod.rb
@@ -1,0 +1,26 @@
+# Use `x.pow(m - 2, m)` instead of `inv_mod(x, m)` m is a prime number.
+def inv_mod(x, m)
+  z = inv_gcd(x, m)
+  raise ArgumentError unless z.first == 1
+
+  z[1]
+end
+
+def inv_gcd(a, b)
+  a %= b # safe_mod
+
+  s, t = b, a
+  m0, m1 = 0, 1
+
+  while t > 0
+    u = s / t
+    s -= t * u
+    m0 -= m1 * u
+
+    s, t = t, s
+    m0, m1 = m1, m0
+  end
+
+  m0 += b / s if m0 < 0
+  [s, m0]
+end

--- a/lib/pow_mod.rb
+++ b/lib/pow_mod.rb
@@ -1,0 +1,13 @@
+# Use `Integer#pow` unless m == 1
+def pow_mod(x, n, m)
+  return 0 if m == 1
+
+  r, y = 1, x % m
+  while n > 0
+    r = r * y % m if n.odd?
+    y = y * y % m
+    n >>= 1
+  end
+
+  r
+end

--- a/test/inv_mod_test.rb
+++ b/test/inv_mod_test.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+require 'minitest'
+require 'minitest/autorun'
+
+require_relative '../lib/inv_mod.rb'
+
+class InvModTest < Minitest::Test
+  def test_prime_mod
+    assert_equal 1, inv_mod(1, 11)
+    assert_equal 6, inv_mod(2, 11)
+    assert_equal 4, inv_mod(3, 11)
+    assert_equal 3, inv_mod(4, 11)
+    assert_equal 9, inv_mod(5, 11)
+    assert_equal 2, inv_mod(6, 11)
+    assert_equal 8, inv_mod(7, 11)
+    assert_equal 7, inv_mod(8, 11)
+    assert_equal 5, inv_mod(9, 11)
+    assert_equal 10, inv_mod(10, 11)
+
+    (1 .. 10).each do |i|
+      assert_equal i.pow(11 - 2, 11), inv_mod(i, 11)
+    end
+  end
+
+  def test_not_prime_mod
+    assert_equal 1, inv_mod(1, 10)
+    assert_equal 7, inv_mod(3, 10)
+    assert_equal 3, inv_mod(7, 10)
+    assert_equal 9, inv_mod(9, 10)
+  end
+
+  def test_inv_hand
+    min_ll = -2**63
+    max_ll = 2**63 - 1
+    assert_equal inv_mod(-1, max_ll), inv_mod(min_ll, max_ll)
+    assert_equal 1, inv_mod(max_ll, max_ll - 1)
+    assert_equal max_ll - 1, inv_mod(max_ll - 1, max_ll)
+    assert_equal 2, inv_mod(max_ll / 2 + 1, max_ll)
+  end
+
+  def test_inv_mod
+    (-100 .. 100).each do |a|
+      (1 .. 1000).each do |b|
+        next unless 1 == (a % b).gcd(b)
+
+        c = inv_mod(a, b)
+        assert 0 <= c
+        assert c < b
+        assert_equal 1 % b, (a * c) % b
+      end
+    end
+  end
+
+  def test_inv_mod_zero
+    assert_equal 0, inv_mod(0, 1)
+    10.times do |i|
+      assert_equal 0, inv_mod(i, 1)
+      assert_equal 0, inv_mod(-i, 1)
+    end
+  end
+end

--- a/test/inv_mod_test.rb
+++ b/test/inv_mod_test.rb
@@ -17,6 +17,8 @@ class InvModTest < Minitest::Test
     assert_equal 7, inv_mod(8, 11)
     assert_equal 5, inv_mod(9, 11)
     assert_equal 10, inv_mod(10, 11)
+    assert_equal 1, inv_mod(12, 11)
+    assert_equal 6, inv_mod(13, 11)
 
     (1 .. 10).each do |i|
       assert_equal i.pow(11 - 2, 11), inv_mod(i, 11)
@@ -28,6 +30,11 @@ class InvModTest < Minitest::Test
     assert_equal 7, inv_mod(3, 10)
     assert_equal 3, inv_mod(7, 10)
     assert_equal 9, inv_mod(9, 10)
+
+    assert_equal 1, inv_mod(11, 10)
+    assert_equal 7, inv_mod(13, 10)
+    assert_equal 3, inv_mod(17, 10)
+    assert_equal 9, inv_mod(19, 10)
   end
 
   def test_inv_hand

--- a/test/pow_mod_test.rb
+++ b/test/pow_mod_test.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require 'minitest'
+require 'minitest/autorun'
+
+require_relative '../lib/pow_mod.rb'
+
+def naive_pow_mod(x, n, mod)
+  y = x % mod
+  z = 1 % mod
+  n.times { z = (z * y) % mod }
+  z
+end
+
+class InvModTest < Minitest::Test
+  def test_prime_mod
+    (-10 .. 10).each do |a|
+      (0 .. 10).each do |b|
+        (2 .. 10).each do |c|
+          assert_equal naive_pow_mod(a, b, c), pow_mod(a, b, c)
+          # assert_equal naive_pow_mod(a, b, c), a.pow(b, c)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
本家ライブラリの`pow_mod`と`inv_mod`関数を用意しました。
もともとRubyにはmodular powerの`pow`があるので、基本的には不要です。
ただ、以下の理由などにより、追加することにしました。
- 本家ライブラリの再現のため
- 本家ライブラリの`inv_mod`は、拡張ユークリッドの互除法を用いて、modが非素数の場合にも対応している。
- Ruby 2.7.1で、`n.pow(0, 1)`でmod 1なのに1を返す小さなバグがある。
- ドキュメントでRubyにもともとある`pow`を使うべき旨を書くため。

基本的に、本家ライブラリの実装に合わせて書いています。
違う点は、以下のような点です。
- C++は負数を割ると負数が返ってきますが、Rubyでは正数で割れば正数が返るので、`safe_mod`などは実装していません。
- C++で0が偽であることを利用した条件文を書いてるところで、`> 0`で判定しています。
- C++で0が偽であることを利用して`(n & 1)`と書いてるところを、Rubyで`n.odd?`としました。
- 本家ライブラリで実装されている`barrett`も、少し面倒そうな割に旨味が少ないかと思い実装していません(要検証)。

あと、お行儀が悪いですが、他のところのドキュメントのリンクの修正も混ぜてしまってます。