### PR TITLE
Improve `DSU#groups` by using `group_by`

### DIFF
--- a/lib/dsu.rb
+++ b/lib/dsu.rb
@@ -6,6 +6,8 @@ class DSU
     @parent_or_size = Array.new(n, -1)
   end
 
+  attr_accessor :parent_or_size
+
   def merge(a, b)
     x = leader(a)
     y = leader(b)
@@ -33,16 +35,8 @@ class DSU
     -@parent_or_size[leader(a)]
   end
 
-  def groups_with_leader
-    h = Hash.new { |hash, key| hash[key] = [] }
-    @parent_or_size.size.times do |i|
-      h[leader(i)] << i
-    end
-    h
-  end
-
   def groups
-    groups_with_leader.values
+    (0 ... @parent_or_size.size).group_by{ |i| leader(i) }.values
   end
 end
 


### PR DESCRIPTION
Issue #66 への対応です。
`DSU#groups`を`group_by`メソッドを使ってコードをシンプルにするリファクタリングです。
(あと、ついでに`parent_or_size`にデバッグ用にゲッター・セッターを追加しました。)

以前のコードと改善案2つの計3つで、手元で時間計測しましたが大きな違いはなく、
[AtCoder ARC106 B \- Values](https://atcoder.jp/contests/arc106/tasks/arc106_b)で実際に提出してみた結果も大差はなかったですが、1番速かった`Range`と`group_by`を用いた方法に変更したいと思います。個人的にこっちの方が`times`を使う方よりわかりやすいと思っているのもあります。

[387ms](https://atcoder.jp/contests/arc106/submissions/17767235) `Range`と`group_by`
```ruby
  def groups
    (0 ... @parent_or_size.size).group_by{ |i| leader(i) }.values
  end
```

[409ms](https://atcoder.jp/contests/arc106/submissions/17767247) `times`と`group_by`
```ruby
  def groups
    @parent_or_size.size.times.group_by{ |i| leader(i) }.values
  end
```

[396ms](https://atcoder.jp/contests/arc106/submissions/17767269) 以前のコードをまとめたもの。
```ruby
  def groups
    h = Hash.new { |hash, key| hash[key] = [] }
    @parent_or_size.size.times do |i|
      h[leader(i)] << i
    end
    h.values
  end
```

close #66