### PR TITLE
Improve speed for z_algorithm by using codepoints(z_aligorithmの定数倍高速化)

### DIFF
--- a/lib/z_algorithm.rb
+++ b/lib/z_algorithm.rb
@@ -1,11 +1,13 @@
 # this implementation is different from ACL because of calculation time
 # ref : https://snuke.hatenablog.com/entry/2014/12/03/214243
-# ACL  implementation : https://atcoder.jp/contests/abc135/submissions/16656972 (1320 ms)
-# this implementation : https://atcoder.jp/contests/abc135/submissions/16656965 (1076 ms)
+# ACL  implementation : https://atcoder.jp/contests/abc135/submissions/18836384 (731ms)
+# this implementation : https://atcoder.jp/contests/abc135/submissions/18836378 (525ms)
 
 def z_algorithm(s)
   n = s.size
   return [] if n == 0
+
+  s = s.codepoints if s.is_a?(String)
 
   z = [0] * n
   z[0] = n


### PR DESCRIPTION
If the argument of z_algorithm is a String, convert this argument to an Array by `String#codepoints`.

String:
- ACL  implementation : https://atcoder.jp/contests/abc135/submissions/16656972 (1320 ms)
- this implementation : https://atcoder.jp/contests/abc135/submissions/16656965 (1076 ms)

↓
Array whose elements are Integer:
- ACL  implementation : https://atcoder.jp/contests/abc135/submissions/18836384 (731ms)
- this implementation : https://atcoder.jp/contests/abc135/submissions/18836378 (525ms)

文字列の添字による参照が配列の添字による参照よりもだいぶ遅いので、`String#codepoints`で数値の配列に変換しています。
`String#bytes`ではなく、`String#codepoints`を使用したのは、アスキー以外の文字にも対応できた方が嬉しいかと思い、そうしました。この2つに関して、特にスピード差はないかなと思ってます。