### PR TITLE
Make ac-library-rb a gem

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,11 @@
+/.bundle/
+/.yardoc
+/_yardoc/
+/coverage/
+/doc/
+/pkg/
+/spec/reports/
+/tmp/
+Gemfile.lock
+
+/free_space

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,9 +1,18 @@
 AllCops:
   NewCops: enable
+  Exclude:
+    - 'lib_lock/ac-library-rb/*.rb'
 Layout/ExtraSpacing:
   AutoCorrect: false
   Exclude:
+    - 'ac-library-rb.gemspec'
     - 'test/convolution_test.rb'
+Layout/LineLength:
+  Exclude:
+    - 'ac-library-rb.gemspec'
+Layout/SpaceAroundOperators:
+  Exclude:
+    - 'ac-library-rb.gemspec'
 Layout/SpaceBeforeBlockBraces:
   Enabled: false
 Layout/SpaceInsideArrayLiteralBrackets:
@@ -52,7 +61,7 @@ Lint/Void:
   Exclude:
     - 'test/example/*'
 Metrics/AbcSize:
-  Max: 49
+  Max: 50
   Exclude:
     - 'lib/suffix_array.rb'
     - 'test/modint_test.rb'
@@ -77,12 +86,17 @@ Metrics/PerceivedComplexity:
   Max: 13
   Exclude:
     - 'lib/suffix_array.rb'
+Naming/FileName:
+  Exclude:
+    - 'lib_lock/ac-library-rb.rb'
 Naming/AccessorMethodName:
   Exclude:
     - 'lib/modint.rb'
 Naming/MethodName:
   Exclude:
+    - 'lib/core_ext/modint.rb'
     - 'lib/modint.rb'
+    - 'lib_lock/ac-library-rb/core_ext/modint.rb'
     - 'test/convolution_test.rb'
 Naming/MethodParameterName:
   Enabled: false
@@ -101,6 +115,8 @@ Style/BlockDelimiters:
     - 'test/lcp_array_test.rb'
     - 'test/suffix_array_test.rb'
     - 'test/z_algorithm_test.rb'
+Style/Documentation:
+  Enabled: false
 Style/GlobalVars:
   AutoCorrect: false
   Exclude:
@@ -115,6 +131,12 @@ Style/Lambda:
   Enabled: false
 Style/LambdaCall:
   Enabled: false
+Style/HashSyntax:
+  Exclude:
+    - 'Rakefile'
+Style/MixinUsage:
+  Exclude:
+    - 'lib_lock/ac-library-rb.rb'
 Style/MultipleComparison:
   Enabled: false
 Style/NegatedIf:
@@ -161,9 +183,14 @@ Style/SpecialGlobalVars:
   Exclude:
     - 'test/example/convolution_practice.rb'
     - 'test/example/crt.rb'
+Style/StringConcatenation:
+  Exclude:
+    - 'bin/lock_lib.rb'
 Style/StringLiterals:
   Enabled: false
 Style/TrailingCommaInArrayLiteral:
+  Enabled: false
+Style/WordArray:
   Enabled: false
 Style/WhileUntilModifier:
   Enabled: false

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,3 @@
+source "https://rubygems.org"
+
+gemspec

--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,11 @@
+require "bundler/gem_tasks"
+require "rake/testtask"
+
+Rake::TestTask.new(:test) do |t|
+  require_relative "./bin/lock_lib.rb"
+  t.libs << "test"
+  t.libs << "lib"
+  t.test_files = FileList["test/**/*_test.rb"]
+end
+
+task :default => :test

--- a/ac-library-rb.gemspec
+++ b/ac-library-rb.gemspec
@@ -1,0 +1,32 @@
+require_relative 'lib/ac-library-rb/version'
+
+gem_description = "ac-library-rb is a ruby port of AtCoder Library (ACL).
+DSU(UnionFind), FenwickTree, PriorityQueue, Segtree, SCC, 2-SAT, suffix_array, lcp_array, z_algorithm, crt, inv_mod, floor_sum, max_flow, min_cost_flow......"
+
+Gem::Specification.new do |spec|
+  spec.name          = "ac-library-rb"
+  spec.version       = AcLibraryRb::VERSION
+  spec.authors       = ["universato"]
+  spec.email         = ["universato@gmail.com"]
+
+  spec.summary       = "ac-library-rb is a ruby port of AtCoder Library (ACL)."
+  spec.description   = gem_description
+  spec.homepage      = "https://github.com/universato/ac-library-rb"
+  spec.license       = "CC0"
+  spec.required_ruby_version = Gem::Requirement.new(">= 2.3.0")
+
+  spec.metadata["homepage_uri"] = spec.homepage
+  spec.metadata["source_code_uri"] = "https://github.com/universato/ac-library-rb"
+
+  spec.add_development_dependency "minitest"
+  spec.add_development_dependency "rake"
+
+  # Specify which files should be added to the gem when it is released.
+  # The `git ls-files -z` loads the files in the RubyGem that have been added into git.
+  spec.files         = Dir.chdir(File.expand_path('..', __FILE__)) do
+    `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
+  end
+  spec.bindir        = "exe"
+  spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
+  spec.require_paths = ["lib_lock", "lib_helpers"]
+end

--- a/bin/console
+++ b/bin/console
@@ -1,0 +1,8 @@
+#!/usr/bin/env ruby
+
+require "bundler/setup"
+
+require "ac-library-rb"
+
+require "irb"
+IRB.start(__FILE__)

--- a/bin/lock_lib.rb
+++ b/bin/lock_lib.rb
@@ -1,0 +1,27 @@
+require 'pathname'
+
+# copy libraries from `lib` to `lib_lock/ac-library` and add `module AcLibraryRb`
+lib_path = File.expand_path('../../lib/**', __FILE__)
+lock_dir = File.expand_path('../../lib_lock/ac-library-rb', __FILE__)
+Dir.glob(lib_path) do |file|
+  next unless FileTest.file?(file)
+
+  path = Pathname.new(lock_dir) + Pathname.new(file).basename
+  File.open(path, "w") do |f|
+    f.puts "module AcLibraryRb"
+    f.puts File.readlines(file).map{ |line| line == "\n" ? "\n" : '  ' + line }
+    f.puts "end"
+  end
+end
+
+# cope library from `lib/core_ext` to `lib_lock/ac-library-rb/core_ext`
+lib_path = File.expand_path('../../lib/core_ext/**', __FILE__)
+lock_dir = File.expand_path('../../lib_lock/ac-library-rb/core_ext', __FILE__)
+Dir.glob(lib_path) do |file|
+  next unless FileTest.file?(file)
+
+  path = Pathname.new(lock_dir) + Pathname.new(file).basename
+  File.open(path, "w") do |f|
+    f.puts File.readlines(file)
+  end
+end

--- a/bin/setup
+++ b/bin/setup
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -euo pipefail
+IFS=$'\n\t'
+set -vx
+
+bundle install
+
+# Do any other automated setup that you need to do here

--- a/lib/ac-library-rb/version.rb
+++ b/lib/ac-library-rb/version.rb
@@ -1,0 +1,3 @@
+module AcLibraryRb
+  VERSION = "0.5.0".freeze
+end

--- a/lib/core_ext/modint.rb
+++ b/lib/core_ext/modint.rb
@@ -1,0 +1,19 @@
+def ModInt(val)
+  ModInt.new(val)
+end
+
+# Integer
+class Integer
+  def to_modint
+    ModInt.new(self)
+  end
+  alias to_m to_modint
+end
+
+# String
+class String
+  def to_modint
+    ModInt.new(to_i)
+  end
+  alias to_m to_modint
+end

--- a/lib/min_cost_flow.rb
+++ b/lib/min_cost_flow.rb
@@ -1,4 +1,4 @@
-require_relative '../lib/priority_queue.rb'
+require_relative './priority_queue.rb'
 
 # Min Cost Flow Grapsh
 class MinCostFlow

--- a/lib/modint.rb
+++ b/lib/modint.rb
@@ -1,3 +1,5 @@
+require_relative './core_ext/modint.rb'
+
 # ModInt
 class ModInt < Numeric
   class << self
@@ -165,24 +167,4 @@ class ModInt < Numeric
       g == 1 ? x : raise(RangeError, 'no inverse')
     end
   end
-end
-
-def ModInt(val)
-  ModInt.new(val)
-end
-
-# Integer
-class Integer
-  def to_modint
-    ModInt.new(self)
-  end
-  alias to_m to_modint
-end
-
-# String
-class String
-  def to_modint
-    ModInt.new(to_i)
-  end
-  alias to_m to_modint
 end

--- a/lib_helpers/ac-library-rb/all.rb
+++ b/lib_helpers/ac-library-rb/all.rb
@@ -1,0 +1,22 @@
+require_relative "../../lib_lock/ac-library-rb/convolution"
+require_relative "../../lib_lock/ac-library-rb/crt"
+require_relative "../../lib_lock/ac-library-rb/dsu"
+require_relative "../../lib_lock/ac-library-rb/fenwick_tree"
+require_relative "../../lib_lock/ac-library-rb/floor_sum"
+require_relative "../../lib_lock/ac-library-rb/inv_mod"
+require_relative "../../lib_lock/ac-library-rb/lazy_segtree"
+require_relative "../../lib_lock/ac-library-rb/lcp_array"
+require_relative "../../lib_lock/ac-library-rb/max_flow"
+require_relative "../../lib_lock/ac-library-rb/min_cost_flow"
+require_relative "../../lib_lock/ac-library-rb/modint"
+require_relative "../../lib_lock/ac-library-rb/pow_mod"
+require_relative "../../lib_lock/ac-library-rb/priority_queue"
+require_relative "../../lib_lock/ac-library-rb/scc"
+require_relative "../../lib_lock/ac-library-rb/segtree"
+require_relative "../../lib_lock/ac-library-rb/suffix_array"
+require_relative "../../lib_lock/ac-library-rb/two_sat"
+require_relative "../../lib_lock/ac-library-rb/z_algorithm"
+
+# Usage:
+#   require 'ac-library-rb/all'
+#   include AcLibraryRb

--- a/lib_lock/ac-library-rb.rb
+++ b/lib_lock/ac-library-rb.rb
@@ -1,0 +1,22 @@
+module AcLibraryRb
+end
+include AcLibraryRb
+
+require_relative './ac-library-rb/convolution'
+require_relative './ac-library-rb/crt'
+require_relative './ac-library-rb/dsu'
+require_relative './ac-library-rb/fenwick_tree'
+require_relative './ac-library-rb/floor_sum'
+require_relative './ac-library-rb/inv_mod'
+require_relative './ac-library-rb/lazy_segtree'
+require_relative './ac-library-rb/lcp_array'
+require_relative './ac-library-rb/max_flow'
+require_relative './ac-library-rb/min_cost_flow'
+require_relative './ac-library-rb/modint'
+require_relative './ac-library-rb/pow_mod'
+require_relative './ac-library-rb/priority_queue'
+require_relative './ac-library-rb/scc'
+require_relative './ac-library-rb/segtree'
+require_relative './ac-library-rb/suffix_array'
+require_relative './ac-library-rb/two_sat'
+require_relative './ac-library-rb/z_algorithm'

--- a/lib_lock/ac-library-rb/convolution.rb
+++ b/lib_lock/ac-library-rb/convolution.rb
@@ -1,0 +1,126 @@
+module AcLibraryRb
+  # usage :
+  #
+  # conv = Convolution.new(mod, [primitive_root])
+  # conv.convolution(a, b) #=> convolution a and b modulo mod.
+  #
+  class Convolution
+    def initialize(mod = 998_244_353, primitive_root = nil)
+      @mod = mod
+
+      cnt2 = bsf(@mod - 1)
+      e = (primitive_root || calc_primitive_root(mod)).pow((@mod - 1) >> cnt2, @mod)
+      ie = e.pow(@mod - 2, @mod)
+
+      es = [0] * (cnt2 - 1)
+      ies = [0] * (cnt2 - 1)
+      cnt2.downto(2){ |i|
+        es[i - 2] = e
+        ies[i - 2] = ie
+        e = e * e % @mod
+        ie = ie * ie % @mod
+      }
+      now = inow = 1
+
+      @sum_e = [0] * cnt2
+      @sum_ie = [0] * cnt2
+      (cnt2 - 1).times{ |i|
+        @sum_e[i] = es[i] * now % @mod
+        now = now * ies[i] % @mod
+        @sum_ie[i] = ies[i] * inow % @mod
+        inow = inow * es[i] % @mod
+      }
+    end
+
+    def convolution(a, b)
+      n = a.size
+      m = b.size
+      return [] if n == 0 || m == 0
+
+      h = (n + m - 2).bit_length
+      raise ArgumentError if h > @sum_e.size
+
+      z = 1 << h
+
+      a = a + [0] * (z - n)
+      b = b + [0] * (z - m)
+
+      batterfly(a, h)
+      batterfly(b, h)
+
+      c = a.zip(b).map{ |a, b| a * b % @mod }
+
+      batterfly_inv(c, h)
+
+      iz = z.pow(@mod - 2, @mod)
+      return c[0, n + m - 1].map{ |c| c * iz % @mod }
+    end
+
+    def batterfly(a, h)
+      1.upto(h){ |ph|
+        w = 1 << (ph - 1)
+        p = 1 << (h - ph)
+        now = 1
+        w.times{ |s|
+          offset = s << (h - ph + 1)
+          offset.upto(offset + p - 1){ |i|
+            l = a[i]
+            r = a[i + p] * now % @mod
+            a[i] = l + r
+            a[i + p] = l - r
+          }
+          now = now * @sum_e[bsf(~s)] % @mod
+        }
+      }
+    end
+
+    def batterfly_inv(a, h)
+      h.downto(1){ |ph|
+        w = 1 << (ph - 1)
+        p = 1 << (h - ph)
+        inow = 1
+        w.times{ |s|
+          offset = s << (h - ph + 1)
+          offset.upto(offset + p - 1){ |i|
+            l = a[i]
+            r = a[i + p]
+            a[i] = l + r
+            a[i + p] = (l - r) * inow % @mod
+          }
+          inow = inow * @sum_ie[bsf(~s)] % @mod
+        }
+      }
+    end
+
+    def bsf(x)
+      (x & -x).bit_length - 1
+    end
+
+    def calc_primitive_root(mod)
+      return 1 if mod == 2
+      return 3 if mod == 998_244_353
+
+      divs = [2]
+      x = (mod - 1) / 2
+      x /= 2 while x.even?
+      i = 3
+      while i * i <= x
+        if x % i == 0
+          divs << i
+          x /= i while x % i == 0
+        end
+        i += 2
+      end
+      divs << x if x > 1
+
+      g = 2
+      loop{
+        return g if divs.none?{ |d| g.pow((mod - 1) / d, mod) == 1 }
+
+        g += 1
+      }
+    end
+
+    private :batterfly, :batterfly_inv, :bsf, :calc_primitive_root
+  end
+end

--- a/lib_lock/ac-library-rb/core_ext/modint.rb
+++ b/lib_lock/ac-library-rb/core_ext/modint.rb
@@ -1,0 +1,19 @@
+def ModInt(val)
+  ModInt.new(val)
+end
+
+# Integer
+class Integer
+  def to_modint
+    ModInt.new(self)
+  end
+  alias to_m to_modint
+end
+
+# String
+class String
+  def to_modint
+    ModInt.new(to_i)
+  end
+  alias to_m to_modint
+end

--- a/lib_lock/ac-library-rb/crt.rb
+++ b/lib_lock/ac-library-rb/crt.rb
@@ -1,0 +1,54 @@
+module AcLibraryRb
+  # return [rem, mod] or [0, 0] (if no solution)
+  def crt(r, m)
+    raise ArgumentError if r.size != m.size
+
+    n = r.size
+    r0, m0 = 0, 1
+    n.times do |i|
+      raise ArgumentError if m[i] < 1
+
+      r1, m1 = r[i] % m[i], m[i]
+      if m0 < m1
+        r0, r1 = r1, r0
+        m0, m1 = m1, m0
+      end
+
+      if m0 % m1 == 0
+        return [0, 0] if r0 % m1 != r1
+
+        next
+      end
+
+      g, im = inv_gcd(m0, m1)
+      u1 = m1 / g
+      return [0, 0] if (r1 - r0) % g != 0
+
+      x = (r1 - r0) / g * im % u1
+      r0 += x * m0
+      m0 *= u1
+      r0 += m0 if r0 < 0
+    end
+
+    return [r0, m0]
+  end
+
+  # internal method
+  # return [g, x] s.t. g = gcd(a, b), x*a = g (mod b), 0 <= x < b/g
+  def inv_gcd(a, b)
+    a %= b
+    return [b, 0] if a == 0
+
+    s, t = b, a
+    m0, m1 = 0, 1
+    while t > 0
+      u, s = s.divmod(t)
+      m0 -= m1 * u
+      s, t = t, s
+      m0, m1 = m1, m0
+    end
+    m0 += b / s if m0 < 0
+
+    return [s, m0]
+  end
+end

--- a/lib_lock/ac-library-rb/dsu.rb
+++ b/lib_lock/ac-library-rb/dsu.rb
@@ -1,0 +1,46 @@
+module AcLibraryRb
+  # Disjoint Set Union
+  class DSU
+    def initialize(n = 0)
+      # root node: -1 * component size
+      # otherwise: parent
+      @parent_or_size = Array.new(n, -1)
+    end
+
+    attr_accessor :parent_or_size
+
+    def merge(a, b)
+      x = leader(a)
+      y = leader(b)
+      return x if x == y
+
+      x, y = y, x if -@parent_or_size[x] < -@parent_or_size[y]
+      @parent_or_size[x] += @parent_or_size[y]
+      @parent_or_size[y] = x
+    end
+    alias unite merge
+
+    def same(a, b)
+      leader(a) == leader(b)
+    end
+    alias same? same
+
+    def leader(a)
+      @parent_or_size[a] < 0 ? a : (@parent_or_size[a] = leader(@parent_or_size[a]))
+    end
+    alias root leader
+    alias find leader
+
+    def size(a)
+      -@parent_or_size[leader(a)]
+    end
+
+    def groups
+      (0 ... @parent_or_size.size).group_by{ |i| leader(i) }.values
+    end
+  end
+
+  UnionFind        = DSU
+  UnionFindTree    = DSU
+  DisjointSetUnion = DSU
+end

--- a/lib_lock/ac-library-rb/fenwick_tree.rb
+++ b/lib_lock/ac-library-rb/fenwick_tree.rb
@@ -1,0 +1,50 @@
+module AcLibraryRb
+  # Fenwick Tree
+  class FenwickTree
+    attr_reader :data, :size
+
+    def initialize(arg = 0)
+      case arg
+      when Array
+        @size = arg.size
+        @data = [0].concat(arg)
+        (1 ... @size).each do |i|
+          up = i + (i & -i)
+          next if up > @size
+
+          @data[up] += @data[i]
+        end
+      when Integer
+        @size = arg
+        @data = Array.new(@size + 1, 0)
+      else
+        raise ArgumentError
+      end
+    end
+
+    def add(i, x)
+      i += 1
+      while i <= @size
+        @data[i] += x
+        i += (i & -i)
+      end
+    end
+
+    def sum(l, r)
+      _sum(r) - _sum(l)
+    end
+
+    def _sum(i)
+      res = 0
+      while i > 0
+        res += @data[i]
+        i &= i - 1
+      end
+      res
+    end
+  end
+
+  FeTree            = FenwickTree
+  Fetree            = FenwickTree
+  BinaryIndexedTree = FenwickTree
+end

--- a/lib_lock/ac-library-rb/floor_sum.rb
+++ b/lib_lock/ac-library-rb/floor_sum.rb
@@ -1,0 +1,23 @@
+module AcLibraryRb
+  def floor_sum(n, m, a, b)
+    res = 0
+
+    if a >= m
+      res += (n - 1) * n * (a / m) / 2
+      a %= m
+    end
+
+    if b >= m
+      res += n * (b / m)
+      b %= m
+    end
+
+    y_max = (a * n + b) / m
+
+    return res if y_max == 0
+
+    x_max = (m * y_max - b + a - 1) / a
+    res += (n - x_max) * y_max + floor_sum(y_max, a, m, a * x_max - m * y_max + b)
+    res
+  end
+end

--- a/lib_lock/ac-library-rb/inv_mod.rb
+++ b/lib_lock/ac-library-rb/inv_mod.rb
@@ -1,0 +1,28 @@
+module AcLibraryRb
+  # Use `x.pow(m - 2, m)` instead of `inv_mod(x, m)` if m is a prime number.
+  def inv_mod(x, m)
+    z = _inv_gcd(x, m)
+    raise ArgumentError unless z.first == 1
+
+    z[1]
+  end
+
+  def _inv_gcd(a, b)
+    a %= b # safe_mod
+
+    s, t = b, a
+    m0, m1 = 0, 1
+
+    while t > 0
+      u = s / t
+      s -= t * u
+      m0 -= m1 * u
+
+      s, t = t, s
+      m0, m1 = m1, m0
+    end
+
+    m0 += b / s if m0 < 0
+    [s, m0]
+  end
+end

--- a/lib_lock/ac-library-rb/lazy_segtree.rb
+++ b/lib_lock/ac-library-rb/lazy_segtree.rb
@@ -1,0 +1,151 @@
+module AcLibraryRb
+  # Segment tree with Lazy propagation
+  class LazySegtree
+    attr_reader   :d, :lz
+    attr_accessor :op, :mapping, :composition
+
+    def initialize(v, e, id, op, mapping, composition)
+      v = Array.new(v, e) if v.is_a?(Integer)
+
+      @n  = v.size
+      @e  = e
+      @id = id
+      @op = op
+      @mapping = mapping
+      @composition = composition
+
+      @log  = (@n - 1).bit_length
+      @size = 1 << @log
+      @d    = Array.new(2 * @size, e)
+      @lz   = Array.new(@size, id)
+
+      @n.times { |i| @d[@size + i] = v[i] }
+      (@size - 1).downto(1) { |i| update(i) }
+    end
+
+    def set(pos, x)
+      pos += @size
+      @log.downto(1) { |i| push(pos >> i) }
+      @d[pos] = x
+      1.upto(@log) { |i| update(pos >> i) }
+    end
+
+    def get(pos)
+      pos += @size
+      @log.downto(1) { |i| push(pos >> i) }
+      @d[pos]
+    end
+
+    def prod(l, r)
+      return @e if l == r
+
+      l += @size
+      r += @size
+
+      @log.downto(1) do |i|
+        push(l >> i) if (l >> i) << i != l
+        push(r >> i) if (r >> i) << i != r
+      end
+
+      sml = @e
+      smr = @e
+      while l < r
+        if l.odd?
+          sml = @op.call(sml, @d[l])
+          l += 1
+        end
+        if r.odd?
+          r -= 1
+          smr = @op.call(@d[r], smr)
+        end
+        l >>= 1
+        r >>= 1
+      end
+
+      @op.call(sml, smr)
+    end
+
+    def all_prod
+      @d[1]
+    end
+
+    def apply(pos, f)
+      pos += @size
+      @log.downto(1) { |i| push(pos >> i) }
+      @d[pos] = @mapping.call(f, @d[pos])
+      1.upto(@log) { |i| update(pos >> i) }
+    end
+
+    def range_apply(l, r, f)
+      return if l == r
+
+      l += @size
+      r += @size
+
+      @log.downto(1) do |i|
+        push(l >> i) if (l >> i) << i != l
+        push((r - 1) >> i) if (r >> i) << i != r
+      end
+
+      l2 = l
+      r2 = r
+      while l < r
+        (all_apply(l, f); l += 1) if l.odd?
+        (r -= 1; all_apply(r, f)) if r.odd?
+        l >>= 1
+        r >>= 1
+      end
+      l = l2
+      r = r2
+
+      1.upto(@log) do |i|
+        update(l >> i)       if (l >> i) << i != l
+        update((r - 1) >> i) if (r >> i) << i != r
+      end
+    end
+
+    def max_right(l, &g)
+      return @n if l == @n
+
+      l += @size
+      @log.downto(1) { |i| push(l >> i) }
+      sm = @e
+
+      loop do
+        while l.even?
+          l >>= 1
+        end
+        unless g.call(@op.call(sm, @d[l]))
+          while l < @size
+            push(l)
+            l <<= 1
+            if g.call(@op.call(sm, @d[l]))
+              sm = @op.call(sm, @d[l])
+              l += 1
+            end
+          end
+          return l - @size
+        end
+        sm = @op.call(sm, @d[l])
+        l += 1
+        break if l & -l == l
+      end
+      @n
+    end
+
+    def update(k)
+      @d[k] = @op.call(@d[2 * k], @d[2 * k + 1])
+    end
+
+    def all_apply(k, f)
+      @d[k]  = @mapping.call(f, @d[k])
+      @lz[k] = @composition.call(f, @lz[k]) if k < @size
+    end
+
+    def push(k)
+      all_apply(2 * k,     @lz[k])
+      all_apply(2 * k + 1, @lz[k])
+      @lz[k] = @id
+    end
+  end
+end

--- a/lib_lock/ac-library-rb/lcp_array.rb
+++ b/lib_lock/ac-library-rb/lcp_array.rb
@@ -1,0 +1,25 @@
+module AcLibraryRb
+  # lcp array for array of integers or string
+  def lcp_array(s, sa)
+    s = s.bytes if s.is_a?(String)
+
+    n = s.size
+    rnk = [0] * n
+    sa.each_with_index{ |sa, id|
+      rnk[sa] = id
+    }
+
+    lcp = [0] * (n - 1)
+    h = 0
+    n.times{ |i|
+      h -= 1 if h > 0
+      next if rnk[i] == 0
+
+      j = sa[rnk[i] - 1]
+      h += 1 while j + h < n && i + h < n && s[j + h] == s[i + h]
+      lcp[rnk[i] - 1] = h
+    }
+
+    return lcp
+  end
+end

--- a/lib_lock/ac-library-rb/max_flow.rb
+++ b/lib_lock/ac-library-rb/max_flow.rb
@@ -1,0 +1,139 @@
+module AcLibraryRb
+  # MaxFlowGraph
+  class MaxFlow
+    def initialize(n = 0)
+      @n   = n
+      @pos = []
+      @g   = Array.new(n) { [] }
+    end
+
+    def add_edge(from, to, cap)
+      edge_number = @pos.size
+
+      @pos << [from, @g[from].size]
+
+      from_id = @g[from].size
+      to_id   = @g[to].size
+      to_id += 1 if from == to
+      @g[from] << [to,   to_id,   cap]
+      @g[to]   << [from, from_id, 0]
+
+      edge_number
+    end
+
+    def push(edge)
+      add_edge(*edge)
+    end
+    alias << push
+
+    # return edge = [from, to, cap, flow]
+    def [](i)
+      _e  = @g[@pos[i][0]][@pos[i][1]]
+      _re = @g[_e[0]][_e[1]]
+      [@pos[i][0], _e[0], _e[-1] + _re[-1], _re[-1]]
+    end
+    alias get_edge []
+    alias edge []
+
+    def edges
+      @pos.map do |(from, id)|
+        _e  = @g[from][id]
+        _re = @g[_e[0]][_e[1]]
+        [from, _e[0], _e[-1] + _re[-1], _re[-1]]
+      end
+    end
+
+    def change_edge(i, new_cap, new_flow)
+      _e  = @g[@pos[i][0]][@pos[i][1]]
+      _re = @g[_e[0]][_e[1]]
+      _e[2]  = new_cap - new_flow
+      _re[2] = new_flow
+    end
+
+    def flow(s, t, flow_limit = 1 << 64)
+      level = Array.new(@n)
+      iter  = Array.new(@n)
+      que   = []
+
+      flow = 0
+      while flow < flow_limit
+        bfs(s, t, level, que)
+        break if level[t] == -1
+
+        iter.fill(0)
+        while flow < flow_limit
+          f = dfs(t, flow_limit - flow, s, level, iter)
+          break if f == 0
+
+          flow += f
+        end
+      end
+
+      flow
+    end
+    alias max_flow flow
+
+    def min_cut(s)
+      visited = Array.new(@n, false)
+      que = [s]
+      while (q = que.shift)
+        visited[q] = true
+        @g[q].each do |(to, _rev, cap)|
+          if cap > 0 && !visited[to]
+            visited[to] = true
+            que << to
+          end
+        end
+      end
+      visited
+    end
+
+    private
+
+    def bfs(s, t, level, que)
+      level.fill(-1)
+      level[s] = 0
+      que.clear
+      que << s
+
+      while (v = que.shift)
+        @g[v].each do |e|
+          next if e[2] == 0 || level[e[0]] >= 0
+
+          level[e[0]] = level[v] + 1
+          return nil if e[0] == t
+
+          que << e[0]
+        end
+      end
+    end
+
+    def dfs(v, up, s, level, iter)
+      return up if v == s
+
+      res = 0
+      level_v = level[v]
+
+      while iter[v] < @g[v].size
+        i = iter[v]
+        e = @g[v][i]
+        cap = @g[e[0]][e[1]][2]
+        if level_v > level[e[0]] && cap > 0
+          d = dfs(e[0], (up - res < cap ? up - res : cap), s, level, iter)
+          if d > 0
+            @g[v][i][2] += d
+            @g[e[0]][e[1]][2] -= d
+            res += d
+            break if res == up
+          end
+        end
+        iter[v] += 1
+      end
+
+      res
+    end
+  end
+
+  MaxFlowGraph = MaxFlow
+  MFGraph      = MaxFlow
+end

--- a/lib_lock/ac-library-rb/min_cost_flow.rb
+++ b/lib_lock/ac-library-rb/min_cost_flow.rb
@@ -1,0 +1,145 @@
+module AcLibraryRb
+  require_relative './priority_queue.rb'
+
+  # Min Cost Flow Grapsh
+  class MinCostFlow
+    def initialize(n)
+      @n      = n
+      @pos    = []
+      @g_to   = Array.new(n) { [] }
+      @g_rev  = Array.new(n) { [] }
+      @g_cap  = Array.new(n) { [] }
+      @g_cost = Array.new(n) { [] }
+      @pv     = Array.new(n)
+      @pe     = Array.new(n)
+      @dual   = Array.new(n) { 0 }
+    end
+
+    def add_edge(from, to, cap, cost)
+      edge_number = @pos.size
+
+      @pos << [from, @g_to[from].size]
+
+      from_id = @g_to[from].size
+      to_id   = @g_to[to].size
+      to_id += 1 if from == to
+
+      @g_to[from]   << to
+      @g_rev[from]  << to_id
+      @g_cap[from]  << cap
+      @g_cost[from] << cost
+
+      @g_to[to]     << from
+      @g_rev[to]    << from_id
+      @g_cap[to]    << 0
+      @g_cost[to]   << -cost
+
+      edge_number
+    end
+
+    def get_edge(i)
+      from, id = @pos[i]
+      to = @g_to[from][id]
+      rid = @g_rev[from][id]
+      [from, to, @g_cap[from][id] + @g_cap[to][rid], @g_cap[to][rid], @g_cost[from][id]]
+    end
+    alias edge get_edge
+    alias [] get_edge
+
+    def edges
+      @pos.map do |(from, id)|
+        to = @g_to[from][id]
+        rid = @g_rev[from][id]
+        [from, to, @g_cap[from][id] + @g_cap[to][rid], @g_cap[to][rid], @g_cost[from][id]]
+      end
+    end
+
+    def flow(s, t, flow_limit = Float::MAX)
+      slope(s, t, flow_limit).last
+    end
+    alias min_cost_max_flow flow
+
+    def dual_ref(s, t)
+      dist = Array.new(@n, Float::MAX)
+      @pv.fill(-1)
+      @pe.fill(-1)
+      vis = Array.new(@n, false)
+
+      que = PriorityQueue.new { |par, chi| par[0] < chi[0] }
+      dist[s] = 0
+      que.push([0, s])
+
+      while (v = que.pop)
+        v = v[1]
+
+        next if vis[v]
+
+        vis[v] = true
+        break if v == t
+
+        @g_to[v].size.times do |i|
+          to = @g_to[v][i]
+          next if vis[to] || @g_cap[v][i] == 0
+
+          cost = @g_cost[v][i] - @dual[to] + @dual[v]
+          next unless dist[to] - dist[v] > cost
+
+          dist[to] = dist[v] + cost
+          @pv[to] = v
+          @pe[to] = i
+          que.push([dist[to], to])
+        end
+      end
+
+      return false unless vis[t]
+
+      @n.times do |i|
+        next unless vis[i]
+
+        @dual[i] -= dist[t] - dist[i]
+      end
+
+      true
+    end
+
+    def slope(s, t, flow_limit = Float::MAX)
+      flow = 0
+      cost = 0
+      prev_cost = -1
+      result = [[flow, cost]]
+
+      while flow < flow_limit
+        break unless dual_ref(s, t)
+
+        c = flow_limit - flow
+        v = t
+        while v != s
+          c = @g_cap[@pv[v]][@pe[v]] if c > @g_cap[@pv[v]][@pe[v]]
+          v = @pv[v]
+        end
+
+        v = t
+        while v != s
+          nv = @pv[v]
+          id = @pe[v]
+          @g_cap[nv][id] -= c
+          @g_cap[v][@g_rev[nv][id]] += c
+          v = nv
+        end
+
+        d = -@dual[s]
+        flow += c
+        cost += c * d
+        result.pop if prev_cost == d
+        result << [flow, cost]
+        prev_cost = d
+      end
+
+      result
+    end
+    alias min_cost_slop slope
+  end
+
+  MCF      = MinCostFlow
+  MCFGraph = MinCostFlow
+end

--- a/lib_lock/ac-library-rb/modint.rb
+++ b/lib_lock/ac-library-rb/modint.rb
@@ -1,0 +1,172 @@
+module AcLibraryRb
+  require_relative './core_ext/modint.rb'
+
+  # ModInt
+  class ModInt < Numeric
+    class << self
+      def set_mod(mod)
+        raise ArgumentError unless mod.is_a? Integer and 1 <= mod
+
+        $_mod = mod
+        $_mod_is_prime = ModInt.prime?(mod)
+      end
+
+      def mod=(mod)
+        set_mod mod
+      end
+
+      def mod
+        $_mod
+      end
+
+      def raw(val)
+        x = allocate
+        x.val = val.to_i
+        x
+      end
+
+      def prime?(n)
+        return false if n <= 1
+        return true if n == 2 or n == 7 or n == 61
+        return false if (n & 1) == 0
+
+        d = n - 1
+        d >>= 1 while (d & 1) == 0
+        [2, 7, 61].each do |a|
+          t = d
+          y = a.pow(t, n)
+          while t != n - 1 and y != 1 and y != n - 1
+            y = y * y % n
+            t <<= 1
+          end
+          return false if y != n - 1 and (t & 1) == 0
+        end
+        true
+      end
+
+      def inv_gcd(a, b)
+        a %= b
+        return [b, 0] if a == 0
+
+        s, t = b, a
+        m0, m1 = 0, 1
+        while t != 0
+          u = s / t
+          s -= t * u
+          m0 -= m1 * u
+          s, t = t, s
+          m0, m1 = m1, m0
+        end
+        m0 += b / s if m0 < 0
+        [s, m0]
+      end
+    end
+
+    attr_accessor :val
+
+    alias to_i val
+
+    def initialize(val = 0)
+      @val = val.to_i % $_mod
+    end
+
+    def inc!
+      @val += 1
+      @val = 0 if @val == $_mod
+      self
+    end
+
+    def dec!
+      @val = $_mod if @val == 0
+      @val -= 1
+      self
+    end
+
+    def add!(other)
+      @val = (@val + other.to_i) % $_mod
+      self
+    end
+
+    def sub!(other)
+      @val = (@val - other.to_i) % $_mod
+      self
+    end
+
+    def mul!(other)
+      @val = @val * other.to_i % $_mod
+      self
+    end
+
+    def div!(other)
+      mul! inv_internal(other.to_i)
+    end
+
+    def +@
+      self
+    end
+
+    def -@
+      ModInt.raw($_mod - @val)
+    end
+
+    def **(other)
+      $_mod == 1 ? 0 : ModInt.raw(@val.pow(other, $_mod))
+    end
+    alias pow **
+
+    def inv
+      ModInt.raw(inv_internal(@val) % $_mod)
+    end
+
+    def coerce(other)
+      [ModInt(other), self]
+    end
+
+    def +(other)
+      dup.add! other
+    end
+
+    def -(other)
+      dup.sub! other
+    end
+
+    def *(other)
+      dup.mul! other
+    end
+
+    def /(other)
+      dup.div! other
+    end
+
+    def ==(other)
+      @val == other.to_i
+    end
+
+    def dup
+      ModInt.raw(@val)
+    end
+
+    def to_int
+      @val
+    end
+
+    def to_s
+      @val.to_s
+    end
+
+    def inspect
+      "#{@val} mod #{$_mod}"
+    end
+
+    private
+
+    def inv_internal(a)
+      if $_mod_is_prime
+        a != 0 ? a.pow($_mod - 2, $_mod) : raise(RangeError, 'no inverse')
+      else
+        g, x = ModInt.inv_gcd(a, $_mod)
+        g == 1 ? x : raise(RangeError, 'no inverse')
+      end
+    end
+  end
+end

--- a/lib_lock/ac-library-rb/pow_mod.rb
+++ b/lib_lock/ac-library-rb/pow_mod.rb
@@ -1,0 +1,15 @@
+module AcLibraryRb
+  # Use `Integer#pow` unless m == 1
+  def pow_mod(x, n, m)
+    return 0 if m == 1
+
+    r, y = 1, x % m
+    while n > 0
+      r = r * y % m if n.odd?
+      y = y * y % m
+      n >>= 1
+    end
+
+    r
+  end
+end

--- a/lib_lock/ac-library-rb/priority_queue.rb
+++ b/lib_lock/ac-library-rb/priority_queue.rb
@@ -1,0 +1,91 @@
+module AcLibraryRb
+  # Priority Queue
+  # Reference: https://github.com/python/cpython/blob/master/Lib/heapq.py
+  class PriorityQueue
+    # By default, the priority queue returns the maximum element first.
+    # If a block is given, the priority between the elements is determined with it.
+    # For example, the following block is given, the priority queue returns the minimum element first.
+    # `PriorityQueue.new { |x, y| x < y }`
+    #
+    # A heap is an array for which a[k] <= a[2*k+1] and a[k] <= a[2*k+2] for all k, counting elements from 0.
+    def initialize(array = [], &comp)
+      @heap = array
+      @comp = comp || proc { |x, y| x > y }
+      heapify
+    end
+
+    attr_reader :heap
+
+    # Push new element to the heap.
+    def push(item)
+      shift_down(0, @heap.push(item).size - 1)
+    end
+
+    alias << push
+    alias append push
+
+    # Pop the element with the highest priority.
+    def pop
+      latest = @heap.pop
+      return latest if empty?
+
+      ret_item = heap[0]
+      heap[0] = latest
+      shift_up(0)
+      ret_item
+    end
+
+    # Get the element with the highest priority.
+    def get
+      @heap[0]
+    end
+
+    alias top get
+
+    # Returns true if the heap is empty.
+    def empty?
+      @heap.empty?
+    end
+
+    private
+
+    def heapify
+      (@heap.size / 2 - 1).downto(0) { |i| shift_up(i) }
+    end
+
+    def shift_up(pos)
+      end_pos = @heap.size
+      start_pos = pos
+      new_item = @heap[pos]
+      left_child_pos = 2 * pos + 1
+
+      while left_child_pos < end_pos
+        right_child_pos = left_child_pos + 1
+        if right_child_pos < end_pos && @comp.call(@heap[right_child_pos], @heap[left_child_pos])
+          left_child_pos = right_child_pos
+        end
+        # Move the higher priority child up.
+        @heap[pos] = @heap[left_child_pos]
+        pos = left_child_pos
+        left_child_pos = 2 * pos + 1
+      end
+      @heap[pos] = new_item
+      shift_down(start_pos, pos)
+    end
+
+    def shift_down(star_pos, pos)
+      new_item = @heap[pos]
+      while pos > star_pos
+        parent_pos = (pos - 1) >> 1
+        parent = @heap[parent_pos]
+        break if @comp.call(parent, new_item)
+
+        @heap[pos] = parent
+        pos = parent_pos
+      end
+      @heap[pos] = new_item
+    end
+  end
+
+  HeapQueue = PriorityQueue
+end

--- a/lib_lock/ac-library-rb/scc.rb
+++ b/lib_lock/ac-library-rb/scc.rb
@@ -1,0 +1,79 @@
+module AcLibraryRb
+  # Strongly Connected Components
+  class SCCGraph
+    # initialize graph with n vertices
+    def initialize(n = 0)
+      @n, @edges = n, []
+    end
+
+    # add directed edge
+    def add_edge(from, to)
+      raise "invalid params" unless (0...@n).include? from and (0...@n).include? to
+
+      @edges << [from, to]
+    end
+
+    # returns list of strongly connected components
+    # the components are sorted in topological order
+    # O(@n + @edges.size)
+    def scc
+      group_num, ids = scc_ids
+      counts = [0] * group_num
+      ids.each { |x| counts[x] += 1 }
+      groups = Array.new(group_num) { [] }
+      ids.each_with_index { |x, i| groups[x] << i }
+      groups
+    end
+
+    private
+
+    def scc_ids
+      start, elist = csr
+      now_ord = group_num = 0
+      visited, low, ord, ids = [], [], [-1] * @n, []
+      dfs = ->(v) {
+        low[v] = ord[v] = now_ord
+        now_ord += 1
+        visited << v
+        (start[v]...start[v + 1]).each do |i|
+          to = elist[i]
+          low[v] = if ord[to] == -1
+                     dfs.(to)
+                     [low[v], low[to]].min
+                   else
+                     [low[v], ord[to]].min
+                   end
+        end
+        if low[v] == ord[v]
+          loop do
+            u = visited.pop
+            ord[u] = @n
+            ids[u] = group_num
+            break if u == v
+          end
+          group_num += 1
+        end
+      }
+      @n.times { |i| dfs.(i) if ord[i] == -1 }
+      ids = ids.map { |x| group_num - 1 - x }
+      [group_num, ids]
+    end
+
+    def csr
+      start, elist = [0] * (@n + 1), [nil] * @edges.size
+      @edges.each { |(i, _)| start[i + 1] += 1 }
+      @n.times { |i| start[i + 1] += start[i] }
+      counter = start.dup
+      @edges.each do |(i, j)|
+        elist[counter[i]] = j
+        counter[i] += 1
+      end
+      [start, elist]
+    end
+  end
+
+  # class alias
+  StronglyConnectedComponents = SCCGraph
+  SCC  = SCCGraph
+  SCCG = SCCGraph
+end

--- a/lib_lock/ac-library-rb/segtree.rb
+++ b/lib_lock/ac-library-rb/segtree.rb
@@ -1,0 +1,142 @@
+module AcLibraryRb
+  # Segment Tree
+  class Segtree
+    attr_reader :d, :op, :n, :leaf_size, :log
+
+    def initialize(arg = 0, e, &block)
+      case arg
+      when Integer
+        v = Array.new(arg) { e }
+      when Array
+        v = arg
+      end
+
+      @e  = e
+      @op = proc(&block)
+
+      @n = v.size
+      @log = (@n - 1).bit_length
+      @leaf_size = 1 << @log
+      @d = Array.new(@leaf_size * 2) { e }
+      v.each_with_index { |v_i, i| @d[@leaf_size + i] = v_i }
+      (@leaf_size - 1).downto(1) { |i| update(i) }
+    end
+
+    def set(q, x)
+      q += @leaf_size
+      @d[q] = x
+      1.upto(@log) { |i| update(q >> i) }
+    end
+
+    def get(pos)
+      @d[@leaf_size + pos]
+    end
+
+    def prod(l, r)
+      return @e if l == r
+
+      sml = @e
+      smr = @e
+      l += @leaf_size
+      r += @leaf_size
+
+      while l < r
+        if l[0] == 1
+          sml = @op.call(sml, @d[l])
+          l += 1
+        end
+        if r[0] == 1
+          r -= 1
+          smr = @op.call(@d[r], smr)
+        end
+        l /= 2
+        r /= 2
+      end
+
+      @op.call(sml, smr)
+    end
+
+    def all_prod
+      @d[1]
+    end
+
+    def max_right(l, &block)
+      return @n if l == @n
+
+      f = proc(&block)
+
+      l += @leaf_size
+      sm = @e
+      loop do
+        l /= 2 while l.even?
+        unless f.call(@op.call(sm, @d[l]))
+          while l < @leaf_size
+            l *= 2
+            if f.call(@op.call(sm, @d[l]))
+              sm = @op.call(sm, @d[l])
+              l += 1
+            end
+          end
+
+          return l - @leaf_size
+        end
+
+        sm = @op.call(sm, @d[l])
+        l += 1
+        break if (l & -l) == l
+      end
+
+      @n
+    end
+
+    def min_left(r, &block)
+      return 0 if r == 0
+
+      f = proc(&block)
+
+      r += @leaf_size
+      sm = @e
+      loop do
+        r -= 1
+        r /= 2 while r > 1 && r.odd?
+        unless f.call(@op.call(@d[r], sm))
+          while r < @leaf_size
+            r = r * 2 + 1
+            if f.call(@op.call(@d[r], sm))
+              sm = @op.call(@d[r], sm)
+              r -= 1
+            end
+          end
+
+          return r + 1 - @leaf_size
+        end
+
+        sm = @op.call(@d[r], sm)
+        break if (r & -r) == r
+      end
+
+      0
+    end
+
+    def update(k)
+      @d[k] = @op.call(@d[2 * k], @d[2 * k + 1])
+    end
+
+    def inspect
+      t = 0
+      res = "SegmentTree @e = #{@e}, @n = #{@n}, @leaf_size = #{@leaf_size} @op = #{@op}\n  "
+      a = @d[1, @d.size - 1]
+      a.each_with_index do |e, i|
+        res << e.to_s << ' '
+        if t == i && i < @leaf_size
+          res << "\n  "
+          t = t * 2 + 2
+        end
+      end
+      res
+    end
+  end
+
+  SegTree     = Segtree
+  SegmentTree = Segtree
+end

--- a/lib_lock/ac-library-rb/suffix_array.rb
+++ b/lib_lock/ac-library-rb/suffix_array.rb
@@ -1,0 +1,130 @@
+module AcLibraryRb
+  # induce sort (internal method)
+  def sa_is_induce(s, ls, sum_l, sum_s, lms)
+    n = s.size
+    sa = [-1] * n
+
+    buf = sum_s.dup
+    lms.each{ |lms|
+      if lms != n
+        sa[buf[s[lms]]] = lms
+        buf[s[lms]] += 1
+      end
+    }
+
+    buf = sum_l.dup
+    sa[buf[s[-1]]] = n - 1
+    buf[s[-1]] += 1
+    sa.each{ |v|
+      if v >= 1 && !ls[v - 1]
+        sa[buf[s[v - 1]]] = v - 1
+        buf[s[v - 1]] += 1
+      end
+    }
+
+    buf = sum_l.dup
+    sa.reverse_each{ |v|
+      if v >= 1 && ls[v - 1]
+        buf[s[v - 1] + 1] -= 1
+        sa[buf[s[v - 1] + 1]] = v - 1
+      end
+    }
+
+    return sa
+  end
+
+  # SA-IS (internal method)
+  def sa_is(s, upper)
+    n = s.size
+
+    return [] if n == 0
+    return [0] if n == 1
+
+    ls = [false] * n
+    (n - 2).downto(0){ |i|
+      ls[i] = (s[i] == s[i + 1] ? ls[i + 1] : s[i] < s[i + 1])
+    }
+
+    sum_l = [0] * (upper + 1)
+    sum_s = [0] * (upper + 1)
+    n.times{ |i|
+      if ls[i]
+        sum_l[s[i] + 1] += 1
+      else
+        sum_s[s[i]] += 1
+      end
+    }
+    0.upto(upper){ |i|
+      sum_s[i] += sum_l[i]
+      sum_l[i + 1] += sum_s[i] if i < upper
+    }
+
+    lms = (1 ... n).select{ |i| !ls[i - 1] && ls[i] }
+    m = lms.size
+    lms_map = [-1] * (n + 1)
+    lms.each_with_index{ |lms, id| lms_map[lms] = id }
+
+    sa = sa_is_induce(s, ls, sum_l, sum_s, lms)
+
+    return sa if m == 0
+
+    sorted_lms = sa.select{ |sa| lms_map[sa] != -1 }
+    rec_s = [0] * m
+    rec_upper = 0
+    rec_s[lms_map[sorted_lms[0]]] = 0
+    1.upto(m - 1) do |i|
+      l, r = sorted_lms[i - 1, 2]
+      end_l = lms[lms_map[l] + 1] || n
+      end_r = lms[lms_map[r] + 1] || n
+      same = true
+      if end_l - l != end_r - r
+        same = false
+      else
+        while l < end_l
+          break if s[l] != s[r]
+
+          l += 1
+          r += 1
+        end
+        same = false if l == n || s[l] != s[r]
+      end
+      rec_upper += 1 if not same
+      rec_s[lms_map[sorted_lms[i]]] = rec_upper
+    end
+
+    sa_is(rec_s, rec_upper).each_with_index{ |rec_sa, id|
+      sorted_lms[id] = lms[rec_sa]
+    }
+
+    return sa_is_induce(s, ls, sum_l, sum_s, sorted_lms)
+  end
+
+  # suffix array for array of integers or string
+  def suffix_array(s, upper = nil)
+    if not upper
+      case s
+      when Array
+        # compression
+        n = s.size
+        idx = (0 ... n).sort_by{ |i| s[i] }
+        t = [0] * n
+        upper = 0
+        t[idx[0]] = 0
+        1.upto(n - 1){ |i|
+          upper += 1 if s[idx[i - 1]] != s[idx[i]]
+          t[idx[i]] = upper
+        }
+        s = t
+      when String
+        upper = 255
+        s = s.bytes
+      end
+    else
+      s.each{ |s|
+        raise ArgumentError if s < 0 || upper < s
+      }
+    end
+
+    return sa_is(s, upper)
+  end
+end

--- a/lib_lock/ac-library-rb/two_sat.rb
+++ b/lib_lock/ac-library-rb/two_sat.rb
@@ -1,0 +1,36 @@
+module AcLibraryRb
+  require_relative './scc.rb'
+
+  # TwoSAT
+  # Reference: https://github.com/atcoder/ac-library/blob/master/atcoder/twosat.hpp
+  class TwoSAT
+    def initialize(n = 0)
+      @n = n
+      @answer = Array.new(n)
+      @scc = SCCGraph.new(2 * n)
+    end
+
+    attr_reader :answer
+
+    def add_clause(i, f, j, g)
+      raise RangeError unless (0...@n).cover?(i) && (0...@n).cover?(j)
+
+      @scc.add_edge(2 * i + (f ? 0 : 1), 2 * j + (g ? 1 : 0))
+      @scc.add_edge(2 * j + (g ? 0 : 1), 2 * i + (f ? 1 : 0))
+      nil
+    end
+
+    def satisfiable
+      id = @scc.send(:scc_ids)[1]
+      @n.times do |i|
+        return false if id[2 * i] == id[2 * i + 1]
+
+        @answer[i] = id[2 * i] < id[2 * i + 1]
+      end
+      true
+    end
+    alias satisfiable? satisfiable
+  end
+
+  TwoSat = TwoSAT
+end

--- a/lib_lock/ac-library-rb/z_algorithm.rb
+++ b/lib_lock/ac-library-rb/z_algorithm.rb
@@ -1,0 +1,34 @@
+module AcLibraryRb
+  # this implementation is different from ACL because of calculation time
+  # ref : https://snuke.hatenablog.com/entry/2014/12/03/214243
+  # ACL  implementation : https://atcoder.jp/contests/abc135/submissions/18836384 (731ms)
+  # this implementation : https://atcoder.jp/contests/abc135/submissions/18836378 (525ms)
+
+  def z_algorithm(s)
+    n = s.size
+    return [] if n == 0
+
+    s = s.codepoints if s.is_a?(String)
+
+    z = [0] * n
+    z[0] = n
+    i, j = 1, 0
+    while i < n
+      j += 1 while i + j < n && s[j] == s[i + j]
+      z[i] = j
+      if j == 0
+        i += 1
+        next
+      end
+      k = 1
+      while i + k < n && k + z[k] < j
+        z[i + k] = z[k]
+        k += 1
+      end
+      i += k
+      j -= k
+    end
+
+    return z
+  end
+end

--- a/test/all_test.rb
+++ b/test/all_test.rb
@@ -1,0 +1,25 @@
+require_relative 'convolution_test'
+require_relative 'crt_test'
+require_relative 'dsu_test'
+require_relative 'fenwick_tree_test'
+require_relative 'floor_sum_test'
+require_relative 'inv_mod_test'
+require_relative 'lazy_segtree_test'
+require_relative 'lcp_array_test'
+require_relative 'max_flow_test'
+require_relative 'min_cost_flow_test'
+require_relative 'modint_test'
+require_relative 'pow_mod_test'
+require_relative 'priority_queue_test'
+require_relative 'scc_test'
+require_relative 'segtree_test'
+require_relative 'suffix_array_test'
+require_relative 'two_sat_test'
+require_relative 'z_algorithm_test'
+
+require_relative "../lib/ac-library-rb/version"
+class AcLibraryRbTest < Minitest::Test
+  def test_that_it_has_a_version_number
+    refute_nil ::AcLibraryRb::VERSION
+  end
+end


### PR DESCRIPTION
Issue #72 Gem化させる

バージョンは0.5.0でスタートさせようと思います。
完成度に不満があって1.0.0にしたくないのと、だいぶ作ってから日数が経ったし自分が5が好きでキリがいいので。

モジュール化させた方が丁寧だろうという気持ちはあるのですが、
コピペで単純に済ませたいという気持ちもあり、ひとまずモジュール化はさせてないです。

レポジトリ名はac-library-rbだけど、gem名等にもrbがあると見栄えが悪いと思い、gem名等はac-libraryにします。
あと、gem名のスタンダードはアンダースコアなようですが、ac-libraryとハイフン区切りにした方が見栄えがいいと思う等で、ハイフン区切りにします。

ハイフン区切りのgem
ex) aws-sdk-core, sass-rails, selenium-webdriver, multipart-post, concurrent-ruby, acts-as-taggable-on