### PR TITLE
Add latest ruby-version to CI

### DIFF
--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -7,10 +7,11 @@ jobs:
     strategy:
       matrix:
         os: [macos-latest, ubuntu-latest, windows-latest]
+        ruby: [2.7, 3.1]
     steps:
       - uses: actions/checkout@v2
       - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 2.7.1
+          ruby-version: ${{ matrix.ruby }}
       - name: run unittests
         run: ruby test/*.rb


### PR DESCRIPTION
CIにRubyの最新バージョン3.0を追加
↓
CIにRubyの最新バージョン3.1を追加(2022/10/27)